### PR TITLE
fix: platform specific dependencies

### DIFF
--- a/plugins/zapp-generic-chromecast/apple/ZappChromecast.podspec.json
+++ b/plugins/zapp-generic-chromecast/apple/ZappChromecast.podspec.json
@@ -16,7 +16,7 @@
   "requires_arc": true,
   "static_framework": true,
   "swift_versions": "5.1",
-  "source_files": "ios/**/*.swift",
+  "source_files": "ios/**/*.{m,swift}",
   "xcconfig": {
     "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES": "YES",
     "ENABLE_BITCODE": "YES"
@@ -24,9 +24,7 @@
   "dependencies": {
     "ZappCore": [],
     "React": [],
-    "google-cast-sdk-no-bluetooth": [
-      "= 4.4.6"
-    ]
+    "google-cast-sdk-no-bluetooth": ["= 4.4.6"]
   },
   "testspecs": [
     {

--- a/plugins/zapp-generic-chromecast/manifests/manifest.config.js
+++ b/plugins/zapp-generic-chromecast/manifests/manifest.config.js
@@ -40,18 +40,10 @@ function createManifest({ version, platform }) {
     dependency_version: version,
     manifest_version: version,
     min_zapp_sdk: min_zapp_sdk[platform],
-    extra_dependencies: [
-      {
-        ZappChromecast: `:path => './node_modules/${npmDependency}/ZappChromecast.podspec'`,
-      },
-    ],
     api: api[platform],
-    npm_dependencies: `${npmDependency}@${version}`,
-    project_dependencies: [
-      {
-        "react-native-google-cast": `./node_modules/${npmDependency}/android`,
-      },
-    ],
+    extra_dependencies: extra_dependencies[platform],
+    npm_dependencies: [`${npmDependency}@${version}`],
+    project_dependencies: project_dependencies[platform],
     targets: targets[platform],
   };
   return manifest;
@@ -70,8 +62,10 @@ const api_apple = {
   modules: ["ZappChromecast"],
 };
 const api_android = {
+  require_startup_execution: false,
   class_name: "com.applicaster.chromecast.ChromeCastPlugin",
   react_packages: ["com.reactnative.googlecast.GoogleCastPackage"],
+  proguard_rules: "-keep public class com.reactnative.googlecast.** {*;}",
 };
 const api = {
   ios: api_apple,
@@ -80,6 +74,37 @@ const api = {
   tvos_for_quickbrick: api_apple,
   android: api_android,
   android_for_quickbrick: api_android,
+};
+
+const project_dependencies_android = [
+  {
+    "react-native-google-cast":
+      "./node_modules/@applicaster/zapp-generic-chromecast/android/",
+  },
+];
+
+const project_dependencies = {
+  android: project_dependencies_android,
+  android_for_quickbrick: project_dependencies_android,
+  ios: [],
+  ios_for_quickbrick: [],
+  tvos: [],
+  tvos_for_quickbrick: [],
+};
+
+const extra_dependencies_apple = [
+  {
+    ZappChromecast: `:path => './node_modules/${npmDependency}/apple/ZappChromecast.podspec'`,
+  },
+];
+
+const extra_dependencies = {
+  android: [],
+  android_for_quickbrick: [],
+  ios: extra_dependencies_apple,
+  ios_for_quickbrick: extra_dependencies_apple,
+  tvos: [],
+  tvos_for_quickbrick: [],
 };
 
 const mobileTarget = ["mobile"];


### PR DESCRIPTION
This PR should address the issues that users are seeing when building QuickBrick apps that have the Chromecast plugin on iOS and Android. 

I believe that the dependencies were not pointing to the right place. 

### The error

```
error Unable to resolve module `@applicaster/zapp-generic-chromecast` from `node_modules/@applicaster/quick-brick-cast-button/index.js`: @applicaster/zapp-generic-chromecast could not be found within the project.

 
If you are sure the module exists, try these steps:
 
 1. Clear watchman watches: watchman watch-del-all
 
 2. Delete node_modules: rm -rf node_modules and run yarn install
 
 3. Reset Metro's cache: yarn start --reset-cache
 
 4. Remove the cache: rm -rf /tmp/metro-*. Run CLI with --verbose flag for more details.
 
Error: Unable to resolve module `@applicaster/zapp-generic-chromecast` from `node_modules/@applicaster/quick-brick-cast-button/index.js`: @applicaster/zapp-generic-chromecast could not be found within the project.
 

 ```

### The solution

Looks like the main issue was that we were not exporting the Native modules to React. These exports are contained in `.m` files and we were not including these files in the podspec definitions. 

```
  "source_files": "ios/**/*.{m,swift}",
```

With this along with clarifications of the project_dependencies, extra_dependencies per platform I think we should be good.

