### PR TITLE
fix: update chromecast manifest.config.js to not be screen

### DIFF
--- a/plugins/zapp-generic-chromecast/manifests/manifest.config.js
+++ b/plugins/zapp-generic-chromecast/manifests/manifest.config.js
@@ -10,7 +10,6 @@ const baseManifest = {
   description:
     "A react native plugin that allows you to add chromecast support to a QuickBrick based project",
   type: "general",
-  screen: true,
   react_native: true,
   ui_builder_support: true,
   whitelisted_account_ids: [


### PR DESCRIPTION
This PR removes the screen flag in the Chromecast QB plugin manifest, as it mistakenly sets the plugin as a screen plugin every new push