### PR TITLE
fix: correct npm_dependencies in manifest

### DIFF
--- a/plugins/zapp-generic-chromecast/manifests/manifest.config.js
+++ b/plugins/zapp-generic-chromecast/manifests/manifest.config.js
@@ -45,7 +45,7 @@ function createManifest({ version, platform }) {
       },
     ],
     api: api[platform],
-    npm_dependencies: `${npmDependency}@${version}`,
+    npm_dependencies: [`${npmDependency}@${version}`],
     project_dependencies: [
       {
         "react-native-google-cast": `./node_modules/${npmDependency}/android`,


### PR DESCRIPTION
there is an error in the manifest because `npm_dependencies` field isn't wrapped in an array as it should be, and it is causing some builds to fail.
This change doesn't require an new push - I fixed the manifest in Zapp already