### PR TITLE
fix: fix chromecast plugin

### DIFF
--- a/plugins/zapp-generic-chromecast/apple/ZappChromecast.podspec.json
+++ b/plugins/zapp-generic-chromecast/apple/ZappChromecast.podspec.json
@@ -16,7 +16,7 @@
   "requires_arc": true,
   "static_framework": true,
   "swift_versions": "5.1",
-  "source_files": "ios/**/*.swift",
+  "source_files": "ios/**/*.{m,swift}",
   "xcconfig": {
     "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES": "YES",
     "ENABLE_BITCODE": "YES"
@@ -24,9 +24,7 @@
   "dependencies": {
     "ZappCore": [],
     "React": [],
-    "google-cast-sdk-no-bluetooth": [
-      "= 4.4.6"
-    ]
+    "google-cast-sdk-no-bluetooth": ["= 4.4.6"]
   },
   "testspecs": [
     {

--- a/plugins/zapp-generic-chromecast/manifests/manifest.config.js
+++ b/plugins/zapp-generic-chromecast/manifests/manifest.config.js
@@ -1,4 +1,5 @@
 const npmDependency = "@applicaster/zapp-generic-chromecast";
+
 const baseManifest = {
   general: {},
   data: {},
@@ -39,24 +40,32 @@ function createManifest({ version, platform }) {
     dependency_version: version,
     manifest_version: version,
     min_zapp_sdk: min_zapp_sdk[platform],
-    extra_dependencies: [
-      {
-        ZappChromecast: `:path => './node_modules/${npmDependency}/apple/ZappChromecast.podspec'`,
-      },
-    ],
     api: api[platform],
     npm_dependencies: [`${npmDependency}@${version}`],
-    project_dependencies: [
+    targets: ["mobile"],
+  };
+
+  if (platform.includes("android")) {
+    manifest.project_dependencies = [
       {
         "react-native-google-cast": `./node_modules/${npmDependency}/android`,
       },
-    ],
-    targets: targets[platform],
-  };
+    ];
+
+    manifest.extra_dependencies = [];
+  }
+
+  if (platform.includes("ios")) {
+    manifest.extra_dependencies = [
+      {
+        ZappChromecast: `:path => './node_modules/${npmDependency}/apple/ZappChromecast.podspec'`,
+      },
+    ];
+  }
+
   return manifest;
 }
 const min_zapp_sdk = {
-  tvos: "12.1.0-dev",
   ios: "20.1.0-dev",
   android: "20.0.0",
   tvos_for_quickbrick: "0.1.0-alpha1",
@@ -75,21 +84,8 @@ const api_android = {
 const api = {
   ios: api_apple,
   ios_for_quickbrick: api_apple,
-  tvos: api_apple,
-  tvos_for_quickbrick: api_apple,
   android: api_android,
   android_for_quickbrick: api_android,
-};
-
-const mobileTarget = ["mobile"];
-const tvTarget = ["tv"];
-const targets = {
-  ios: mobileTarget,
-  ios_for_quickbrick: mobileTarget,
-  tvos: tvTarget,
-  tvos_for_quickbrick: tvTarget,
-  android: mobileTarget,
-  android_for_quickbrick: mobileTarget,
 };
 
 module.exports = createManifest;

--- a/plugins/zapp-generic-chromecast/manifests/manifest.config.js
+++ b/plugins/zapp-generic-chromecast/manifests/manifest.config.js
@@ -78,8 +78,10 @@ const api_apple = {
   modules: ["ZappChromecast"],
 };
 const api_android = {
+  require_startup_exectution: false,
   class_name: "com.applicaster.chromecast.ChromeCastPlugin",
   react_packages: ["com.reactnative.googlecast.GoogleCastPackage"],
+  roguard_rules: "-keep public class com.reactnative.googlecast.** {*;}",
 };
 const api = {
   ios: api_apple,

--- a/plugins/zapp-generic-chromecast/package.json
+++ b/plugins/zapp-generic-chromecast/package.json
@@ -24,17 +24,17 @@
   "dependencies": {
     "ramda": "^0.26.1"
   },
-  "devDependencies": {
-    "@applicaster/zapplicaster-cli": "3.0.1-rc.3",
-    "react": "16.8.3",
-    "react-native": "0.59.10"
-  },
+  "files": [
+    "android",
+    "apple",
+    "src"
+  ],
   "peerDependencies": {
     "@applicaster/zapp-react-native-redux": "^3.0.0",
     "@applicaster/zapp-react-native-ui-components": "^3.0.0",
     "@applicaster/zapp-react-native-utils": "^3.0.0",
-    "react": "16.8.3",
-    "react-native": "0.59.10"
+    "react": "16.11.0",
+    "react-native": "0.62.2"
   },
   "applicaster": {
     "supportedPlatforms": [


### PR DESCRIPTION
This PR fixes several problems which occured when transitioning the chromecast plugin to the new repo:
- "files" property was missing in the package.json. as a result, non js files were omitted when pushing to npm
- the package had direct dependencies to RN 59
- the manifest was referencing properties for tvos which it doesn't support
- the manifest.config file was adding the extra_dependencies properties for iOS on android platforms as well. as a result, this crashed builds on android (since android uses `extra_dependencies` field as well, but giving it a podspec path generates an error)

