### PR TITLE
fix for ZPP-2784, ZPP-2785 - [Styling] color keys are not taking effect in the app

### DIFF
--- a/plugins/zapp-apple/apple/universal/Helpers/Styles/StylesHelper.swift
+++ b/plugins/zapp-apple/apple/universal/Helpers/Styles/StylesHelper.swift
@@ -47,9 +47,14 @@ class StylesHelper {
     }
     
     public class func style(forKey key: String) -> [String:String]? {
-        guard let universalDict = ZappStyles?[StylesHelperApi.universal] as? [String:[String:String]],
-            let styleDict = universalDict[key] else {
-                return nil
+        var styleDict:[String:String]?
+        if let universalDict = ZappStyles?[StylesHelperApi.universal] as? [String:[String:String]],
+            let value = universalDict[key] {
+            styleDict = value
+        }
+        else if let deviceTypeDict = ZappStyles?[UIDevice.current.model.lowercased()] as? [String:[String:String]],
+            let value = deviceTypeDict[key] {
+            styleDict = value
         }
         return styleDict
     }


### PR DESCRIPTION
[ZPP-2784](https://applicaster.atlassian.net/browse/ZPP-2784) - [Styling] loading_spinner_color key is not taking effect in the app
[ZPP-2785](https://applicaster.atlassian.net/browse/ZPP-2785) - [Styling] loading_error_label key is not taking effect in the app 
