### PR TITLE
fix: send errors as warning on react-native console

### DIFF
--- a/plugins/quick-brick-xray/src/console.ts
+++ b/plugins/quick-brick-xray/src/console.ts
@@ -18,7 +18,14 @@ export function logInConsole(level: XRayLogLevel, event: XRayEvent): void {
       `XRay:: ${category}::${subsystem} - ${event.message}`
     );
     console.log(`event logged at:: ${timestamp}`);
-    console[consoleMethods[level]](otherEventProps);
+
+    if (level === XRayLogLevel.error) {
+      console.warn({ ...otherEventProps, message: `Error:: ${event.message}` });
+      console.error(new Error(event.message));
+    } else {
+      console[consoleMethods[level]](otherEventProps);
+    }
+
     if (level >= XRayLogLevel.warning) {
       console.trace();
     }


### PR DESCRIPTION
React Native's console polyfill only handles invoking `console.error` with a string or an `Error` object, unlike the browser API, which accepts any arguments.

As a result, when XRay is sending events to the console (because the native module isn't available), the RN app will show the Red Box screen with `console.error [Object object]`, and won't send the payload to chrome.

In order to address this, the proxy for sending event to the console now has the following logic:
- if the log level is error, a warning will be sent with the entire event data, adding `Error:: ` to the event message. This will be properly displayed in the console
- on top of the this, console.error is invoked with an `Error` object constructed with the message of the event. this will show in RN's red box.

