### PR TITLE
fix: prevent crash when loginPlugin is undefined

### DIFF
--- a/plugins/video_subscriber_sso_apple/src/SSOProvider.js
+++ b/plugins/video_subscriber_sso_apple/src/SSOProvider.js
@@ -52,7 +52,7 @@ const storeConnector = connectToStore((state, props) => {
   // eslint-disable-next-line array-callback-return,consistent-return
   const plugin = values.find((item) => {
     if (item && item.type) {
-      return item.type === loginPlugin.identifier;
+      return item.type === loginPlugin?.identifier;
     }
   });
 


### PR DESCRIPTION
This PR solves a crash which happens when login plugin isn't found.