### PR TITLE
feat: sanitize event data in Xray

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
   "resolutions": {
     "lodash": "^4.17.19",
     "minimist": "^0.2.1",
-    "mem": "^4.0.0"
+    "mem": "^4.0.0",
+    "node-fetch": "^2.6.1",
+    "yargs-parser": "^13.1.2"
   }
 }

--- a/plugins/quick-brick-xray/src/console.ts
+++ b/plugins/quick-brick-xray/src/console.ts
@@ -1,34 +1,41 @@
 /// <reference types="@types/node" />
+/* eslint-disable no-console */
 import { XRayLogLevel } from "./logLevels";
+import { sanitizeEventData } from "./utils";
 
 const consoleMethods = {
   [XRayLogLevel.verbose]: "log",
   [XRayLogLevel.debug]: "debug",
   [XRayLogLevel.info]: "info",
   [XRayLogLevel.warning]: "warn",
+  [XRayLogLevel.warn]: "warn",
   [XRayLogLevel.error]: "error",
 };
 
 export function logInConsole(level: XRayLogLevel, event: XRayEvent): void {
   const { env } = process;
+
   if (env?.NODE_ENV === "development") {
     const { category, subsystem, ...otherEventProps } = event;
     const timestamp = new Date(Date.now()).toISOString();
+
     console.groupCollapsed(
       `XRay:: ${category}::${subsystem} - ${event.message}`
     );
+
     console.log(`event logged at:: ${timestamp}`);
 
     if (level === XRayLogLevel.error) {
       console.warn({ ...otherEventProps, message: `Error:: ${event.message}` });
       console.error(new Error(event.message));
     } else {
-      console[consoleMethods[level]](otherEventProps);
+      console[consoleMethods[level]](sanitizeEventData(otherEventProps));
     }
 
     if (level >= XRayLogLevel.warning) {
       console.trace();
     }
+
     console.groupEnd();
   }
 }

--- a/plugins/quick-brick-xray/src/index.ts
+++ b/plugins/quick-brick-xray/src/index.ts
@@ -2,7 +2,7 @@ import * as R from "ramda";
 
 import * as logger from "./logger";
 import { Event } from "./Event";
-import { XRayLogLevel } from "./logLevels";
+import { XRayLogLevel as LogLevel } from "./logLevels";
 
 type XRayEventData = {
   message: string;
@@ -10,19 +10,27 @@ type XRayEventData = {
   error?: Error;
 };
 
+export const XRayLogLevel = LogLevel;
+
 export default class Logger implements XRayLoggerI {
   category: string;
   subsystem: string;
   context: AnyDictionary;
   parent?: Logger;
 
-  static logLevels = XRayLogLevel;
+  static logLevels = LogLevel;
 
   constructor(category: string, subsystem: string, parent?: Logger) {
     this.category = category;
     this.subsystem = subsystem;
     this.context = {};
     this.parent = parent || null;
+    this.log = this.log.bind(this);
+    this.debug = this.debug.bind(this);
+    this.info = this.info.bind(this);
+    this.warning = this.warning.bind(this);
+    this.warn = this.warning.bind(this);
+    this.error = this.error.bind(this);
   }
 
   addSubsystem(subsystem: string): Logger {
@@ -71,6 +79,10 @@ export default class Logger implements XRayLoggerI {
       context: this.context,
       ...logEvent,
     });
+  }
+
+  warn(event: string | XRayEventData) {
+    this.warning(event);
   }
 
   error(event: Error | XRayEventData) {

--- a/plugins/quick-brick-xray/src/logLevels.ts
+++ b/plugins/quick-brick-xray/src/logLevels.ts
@@ -3,5 +3,6 @@ export enum XRayLogLevel {
   debug = 1,
   info = 2,
   warning = 3,
+  warn = 3,
   error = 4,
 }

--- a/plugins/quick-brick-xray/src/utils.ts
+++ b/plugins/quick-brick-xray/src/utils.ts
@@ -1,0 +1,79 @@
+type Predicate<T> = (arg: T) => boolean;
+type Transformer<T> = (arg: T) => any;
+type Condition = [Predicate<any>, Transformer<any>];
+type AnyArray = any[];
+type AnyObject = { [K in string]: any };
+type EventData = {
+  [K in "data"]?: any;
+};
+
+function hasProperty(property: string, object: AnyObject): boolean {
+  return Object.prototype.hasOwnProperty.call(object, property);
+}
+
+function isReactClassComponent(value: any): boolean {
+  if (!isObject(value)) {
+    return false;
+  }
+
+  return hasProperty("$$typeof", value) && hasProperty("displayName", value);
+}
+
+function isFunction(value: any): boolean {
+  return typeof value === "function";
+}
+
+function isObject(value: any): boolean {
+  return typeof value === "object" && value !== null;
+}
+
+function True(_: any): boolean {
+  return true;
+}
+
+function cond(conditions: Condition[]) {
+  return function (arg: any): any {
+    let index = 0;
+
+    while (index < conditions.length) {
+      const [predicate, transform] = conditions[index];
+
+      if (predicate(arg)) {
+        return transform(arg);
+      }
+
+      index++;
+    }
+  };
+}
+
+const applyConditions = cond([
+  [isFunction, (value) => `function ${value?.name}` || "anonymous function"],
+  [isReactClassComponent, (value) => `Component ${value.displayName}`],
+  [Array.isArray, sanitizeArrayEntries],
+  [isObject, sanitizeObjectProperties],
+  [True, (value) => value],
+]);
+
+function sanitizeArrayEntries(array: AnyArray): AnyArray {
+  return array.map(applyConditions);
+}
+
+function sanitizeObjectProperties(object: AnyObject): AnyObject {
+  return Object.keys(object).reduce((acc, curr) => {
+    acc[curr] = applyConditions(object[curr]);
+
+    return acc;
+  }, {});
+}
+
+export function sanitizeEventData(event: EventData) {
+  if (!event?.data) {
+    return event;
+  }
+
+  return {
+    ...event,
+    data: applyConditions(event.data),
+  };
+}

--- a/plugins/quick-brick-xray/src/xray.ts
+++ b/plugins/quick-brick-xray/src/xray.ts
@@ -1,6 +1,8 @@
 import { logInConsole } from "./console";
 import { XRayLogLevel } from "./logLevels";
 
+import { sanitizeEventData } from "./utils";
+
 export function logInXray(XRayLoggerBridge: XRayLoggerNativeBridgeI) {
   return function (level: XRayLogLevel, event: XRayEvent): void {
     if (__DEV__) {
@@ -9,6 +11,6 @@ export function logInXray(XRayLoggerBridge: XRayLoggerNativeBridgeI) {
     }
 
     event.context = null; // todo: one of the logged events has cycles in context
-    XRayLoggerBridge.logEvent({ level, ...event });
+    XRayLoggerBridge.logEvent({ level, ...sanitizeEventData(event) });
   };
 }

--- a/plugins/quick-brick-xray/types/index.d.ts
+++ b/plugins/quick-brick-xray/types/index.d.ts
@@ -7,6 +7,7 @@ declare enum XRayLogLevel {
   debug = 1,
   info = 2,
   warning = 3,
+  warn = 3,
   error = 4,
 }
 
@@ -67,6 +68,7 @@ declare interface XRayLoggerI {
   debug(event: XRayEvent): void;
   info(event: XRayEvent): void;
   warning(event: XRayEvent): void;
+  warn(event: XRayEvent): void;
   error(event: XRayEvent): void;
   addContext(context: AnyDictionary): this;
   addSubsystem(subsystem: string): XRayLoggerI;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2110,6 +2110,11 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
+camelcase@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
 camelize@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
@@ -2469,7 +2474,7 @@ debug@^4.0.1, debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.1.1:
+decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -2582,13 +2587,6 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
-
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -3245,7 +3243,7 @@ http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@^0.4.17, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -3519,7 +3517,7 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -4460,18 +4458,10 @@ nigel@3.x.x:
     hoek "6.x.x"
     vise "3.x.x"
 
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
-
-node-fetch@^2.2.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+node-fetch@^1.0.1, node-fetch@^2.2.0, node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -6418,12 +6408,13 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yargs-parser@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
-  integrity sha1-jQrELxbqVd69MyyvTEA4s+P139k=
+yargs-parser@^13.1.2, yargs-parser@^7.0.0:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
   dependencies:
-    camelcase "^4.1.0"
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs@^9.0.0:
   version "9.0.1"


### PR DESCRIPTION
This PR adds a method to sanitize arguments sent through the bridge so that functions and react components sent to Xray native are not crashing the app

It also includes a small fix to avoid confusions & issues between our warning method and the console's `warn` method, plus patches for vulnerabilities