### PR TITLE
Fix: add @applicaster/x-ray as extra_npm_dependencies for android platofrms

### DIFF
--- a/plugins/quick-brick-xray/manifests/manifest.config.js
+++ b/plugins/quick-brick-xray/manifests/manifest.config.js
@@ -31,7 +31,7 @@ function createManifest({ version, platform }) {
     min_zapp_sdk: min_zapp_sdk[platform],
     extra_dependencies: extra_dependencies(platform),
     api: api[platform],
-    npm_dependencies: [`@applicaster/quick-brick-xray@${version}`],
+    npm_dependencies: [`@applicaster/quick-brick-xray@${version}`].concat(extra_npm_dependencies(platform)),
     project_dependencies: project_dependencies[platform],
     targets: targets[platform],
     custom_configuration_fields: custom_configuration_fields[platform],
@@ -173,6 +173,17 @@ function extra_dependencies(platform) {
     return extra_dependencies_apple;
   }
   return null;
+}
+
+function extra_npm_dependencies(platform) {
+  if (
+    platform === "android_for_quickbrick" ||
+    platform === "android_tv_for_quickbrick" ||
+    platform === "amazon_fire_tv_for_quickbrick"
+  ) {
+    return ["@applicaster/x-ray@0.0.10-alpha"];
+  }
+  return [];
 }
 
 const project_dependencies_android = [


### PR DESCRIPTION
Now Apple frameworks declare x-ray npm dependency. Android still needs it to be installed if plugin ins in use.