### PR TITLE
fix(chromecast): Update manifest and mark the plugin as preload: false

### DIFF
--- a/plugins/zapp-generic-chromecast/manifests/manifest.config.js
+++ b/plugins/zapp-generic-chromecast/manifests/manifest.config.js
@@ -20,7 +20,7 @@ const baseManifest = {
   min_zapp_sdk: "0.0.1",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [
     {
       type: "text",


### PR DESCRIPTION
Currently the Chromecast plugin is marked as a preload. 
It is a mistake (you cannot use Chromecast as a hook of course)