### PR TITLE
chore: Update Player dependent plugins to use existing instances if exists

### DIFF
--- a/plugins/video_playing_now_apple/manifests/manifest.config.js
+++ b/plugins/video_playing_now_apple/manifests/manifest.config.js
@@ -16,14 +16,7 @@ const baseManifest = {
   min_zapp_sdk: "0.0.1",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  custom_configuration_fields: [
-    {
-      type: "checkbox",
-      key: "enabled",
-      tooltip_text: "Is plugin enabled on app start",
-      default: 0,
-    },
-  ],
+  custom_configuration_fields: [],
   identifier: "video_playing_now_apple",
   npm_dependencies: [],
   targets: ["mobile"],


### PR DESCRIPTION
1. remove enable param as not really needed
2. update player dependent plugins initialization to use existing instances if exists