### PR TITLE
fix: proper sanitizing of context properties

### DIFF
--- a/plugins/quick-brick-xray/__tests__/logger-native.test.ts
+++ b/plugins/quick-brick-xray/__tests__/logger-native.test.ts
@@ -69,11 +69,6 @@ describe("when XRay Native Module exists", () => {
         SayMyName,
         ClassSayMyName,
       ],
-      context: {
-        Components: { SayMyName, ClassSayMyName },
-        foo: "bar",
-        someFunc() {},
-      },
     };
 
     logger.log(invalidEvent);
@@ -83,14 +78,7 @@ describe("when XRay Native Module exists", () => {
         Array [
           Object {
             "category": "CATEGORY",
-            "context": Object {
-              "Components": Object {
-                "ClassSayMyName": "function ClassSayMyName",
-                "SayMyName": "function SayMyName",
-              },
-              "foo": "bar",
-              "someFunc": "function someFunc",
-            },
+            "context": Object {},
             "data": Object {
               "data": Array [
                 "a string",

--- a/plugins/quick-brick-xray/__tests__/logger.test.ts
+++ b/plugins/quick-brick-xray/__tests__/logger.test.ts
@@ -4,6 +4,8 @@ const { resetSpies, spies } = spyOnConsole();
 
 import XRayLogger from "../src";
 
+const { SayMyName, ClassSayMyName } = require("./reactComponents");
+
 jest.mock("react-native");
 
 const realDate = global.Date;
@@ -109,6 +111,30 @@ describe("logger", () => {
 
     logger.addContext(context);
     expect(logger).toHaveProperty("context", context);
+  });
+
+  it("sanitizes context", () => {
+    const logger = new XRayLogger(CATEGORY, SUBSYSTEM);
+    const context = [
+      {
+        SayMyName,
+        ClassSayMyName,
+        someFunc() {},
+      },
+    ];
+
+    logger.addContext(context);
+    expect(logger.getContext()).toMatchInlineSnapshot(`
+      Object {
+        "context": Array [
+          Object {
+            "ClassSayMyName": "function ClassSayMyName",
+            "SayMyName": "function SayMyName",
+            "someFunc": "function someFunc",
+          },
+        ],
+      }
+    `);
   });
 
   it("merges new context data", () => {

--- a/plugins/quick-brick-xray/src/index.ts
+++ b/plugins/quick-brick-xray/src/index.ts
@@ -3,7 +3,7 @@ import * as R from "ramda";
 import * as logger from "./logger";
 import { Event } from "./Event";
 import { XRayLogLevel as LogLevel } from "./logLevels";
-import { wrapInObject } from "./utils";
+import { applyConditions, wrapInObject } from "./utils";
 
 type XRayEventData = {
   message: string;
@@ -110,15 +110,20 @@ export default class Logger implements XRayLoggerI {
 
   addContext(context: AnyDictionary): this {
     try {
-      this.context = Object.assign(
+      const newContext = Object.assign(
         {},
-        this.parent?.getContext(),
-        this.context,
-        wrapInObject(context, "context")
+        this.getContext(),
+        applyConditions(wrapInObject(context, "context"))
       );
+
+      this.context = newContext;
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.warn("Couldn't sanitize context data", { context });
+      console.warn("Couldn't sanitize context data", {
+        context,
+        e,
+        logger: this,
+      });
     }
 
     return this;

--- a/plugins/quick-brick-xray/src/utils.ts
+++ b/plugins/quick-brick-xray/src/utils.ts
@@ -82,12 +82,11 @@ export const applyConditions = cond([
 
 export function sanitizeEventPayload(event: EventData) {
   try {
-    const { data = {}, context = {} } = event;
+    const { data = {} } = event;
 
     return {
       ...event,
-      data: wrapInObject(applyConditions(data), "data"),
-      context: wrapInObject(applyConditions(context), "context"),
+      data: applyConditions(wrapInObject(data, "data")),
     };
   } catch (error) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
This PR changes the way context properties are sanitizes, by doing it when context is assigned, instead of doing it when events are sent