### PR TITLE
fix: Amazon only needs receiptId

### DIFF
--- a/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/PurchasePromiseListener.kt
+++ b/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/PurchasePromiseListener.kt
@@ -42,5 +42,5 @@ open class PurchasePromiseListener(protected val bridge: IAPBridge,
 
     // hack for Amazon: actual purchase for subscriptions will have another SKU (Parent one)
     protected fun fix(purchase: Purchase) =
-            Purchase(sku, purchase.transactionIdentifier, purchase.receipt, purchase.userId)
+            purchase.copy(productIdentifier = sku)
 }

--- a/plugins/applicaster-iap-framework/android/iap-uni/src/main/java/com/applicaster/iap/uni/amazon/AmazonBillingImpl.kt
+++ b/plugins/applicaster-iap-framework/android/iap-uni/src/main/java/com/applicaster/iap/uni/amazon/AmazonBillingImpl.kt
@@ -177,7 +177,7 @@ class AmazonBillingImpl : IBillingAPI, PurchasingListener {
                 Purchase(
                         receipt.sku,
                         receipt.receiptId,
-                        receipt.toJSON().toString(),
+                        receipt.receiptId,
                         response.userData?.userId
                 )
         )

--- a/plugins/applicaster-iap-framework/android/iap-uni/src/main/java/com/applicaster/iap/uni/amazon/ReceiptStorage.kt
+++ b/plugins/applicaster-iap-framework/android/iap-uni/src/main/java/com/applicaster/iap/uni/amazon/ReceiptStorage.kt
@@ -42,7 +42,7 @@ class ReceiptStorage(context: Context) {
                 val purchase = Purchase(
                         r.sku,
                         r.receiptId,
-                        r.toJSON().toString(),
+                        r.receiptId,
                         userId)
                 edit.putString(r.sku, purchase.toJSON())
             }


### PR DESCRIPTION
Unlike Google, Amazon only needs recieptId.