### PR TITLE
fix: workaround for coroutines bug

### DIFF
--- a/plugins/zapp-push-plugin-firebase/android/build.gradle
+++ b/plugins/zapp-push-plugin-firebase/android/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     if (devSDK != null) {
         implementation project(':applicaster-android-sdk')
     } else {
-        api "com.applicaster:applicaster-android-sdk:$applicasterSDKVersion"
+        api "com.applicaster:applicaster-android-sdk-core:$applicasterSDKVersion"
     }
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     api platform("com.google.firebase:firebase-bom:$firebaseBoMVersion")

--- a/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/factory/DefaultNotificationFactory.kt
+++ b/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/factory/DefaultNotificationFactory.kt
@@ -9,7 +9,7 @@ import kotlin.random.Random
 
 class DefaultNotificationFactory(private val context: Context) : NotificationFactory {
 
-    override suspend fun createNotification(pushMessage: PushMessage): Notification {
+    override fun createNotification(pushMessage: PushMessage): Notification {
         return NotificationUtil.createCustomNotification(
                 context,
                 pushMessage,

--- a/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/factory/NotificationFactory.kt
+++ b/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/factory/NotificationFactory.kt
@@ -5,7 +5,7 @@ import com.applicaster.firebasepushpluginandroid.push.PushMessage
 
 interface NotificationFactory {
 
-    suspend fun createNotification(pushMessage: PushMessage): Notification
+    fun createNotification(pushMessage: PushMessage): Notification
     fun getSmallIconId(): Int
     fun generateNotificationId(): Int
 

--- a/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/notification/NotificationUtil.kt
+++ b/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/notification/NotificationUtil.kt
@@ -9,13 +9,12 @@ import android.media.RingtoneManager
 import android.net.Uri
 import android.provider.Settings
 import android.text.TextUtils
+import androidx.annotation.WorkerThread
 import androidx.core.app.NotificationCompat
 import com.applicaster.firebasepushpluginandroid.push.PushMessage
 import com.applicaster.util.APLogger
 import com.applicaster.util.StringUtil
 import com.bumptech.glide.Glide
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 
 class NotificationUtil {
@@ -27,7 +26,8 @@ class NotificationUtil {
         private const val DEFAULT_SND = "system_default"
         private const val SILENT_PUSH_KEY = "silent"
 
-        suspend fun createCustomNotification(
+        @WorkerThread
+        fun createCustomNotification(
                 context: Context,
                 pushMessage: PushMessage,
                 notificationIconId: Int
@@ -82,20 +82,17 @@ class NotificationUtil {
             return notificationBuilder.build()
         }
 
-        // fetch and downscale remote image asynchronously
-        private suspend fun fetchImage(context: Context, url: String): Bitmap? {
-            return withContext(Dispatchers.Default) {
-                try {
-                    @Suppress("BlockingMethodInNonBlockingContext")
-                    return@withContext Glide.with(context.applicationContext)
-                            .asBitmap()
-                            .load(url)
-                            .submit().get()
-                } catch (e: Exception) {
-                    APLogger.error(TAG, "Failed to fetch image $url", e)
-                }
-                return@withContext null
+        @WorkerThread
+        private fun fetchImage(context: Context, url: String): Bitmap? {
+            try {
+                return Glide.with(context.applicationContext)
+                        .asBitmap()
+                        .load(url)
+                        .submit().get()
+            } catch (e: Exception) {
+                APLogger.error(TAG, "Failed to fetch image $url", e)
             }
+            return null
         }
 
         fun getPushSound(message: PushMessage, context: Context): Uri? {

--- a/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/services/APMessagingService.kt
+++ b/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/services/APMessagingService.kt
@@ -3,6 +3,7 @@ package com.applicaster.firebasepushpluginandroid.services
 import android.net.Uri
 import android.provider.Settings
 import android.text.TextUtils
+import androidx.annotation.WorkerThread
 import androidx.core.app.NotificationManagerCompat
 import com.applicaster.firebasepushpluginandroid.FIREBASE_DEFAULT_CHANNEL_ID
 import com.applicaster.firebasepushpluginandroid.FirebasePushProvider
@@ -69,6 +70,7 @@ class APMessagingService : FirebaseMessagingService() {
         APLogger.info(TAG, "onTokenRefresh")
     }
 
+    @WorkerThread
     private fun processMessageSync(message: RemoteMessage) {
 
         var title: String? = ""
@@ -125,9 +127,9 @@ class APMessagingService : FirebaseMessagingService() {
 
     // set up notification manager, create notification and notify
     private fun notify(notificationFactory: DefaultNotificationFactory, pushMessage: PushMessage) {
+        val notification = notificationFactory.createNotification(pushMessage)
         // run on UI thread, since some devices can't publish notifications from background threads
         GlobalScope.launch(Dispatchers.Main) {
-            val notification = notificationFactory.createNotification(pushMessage)
             with(NotificationManagerCompat.from(this@APMessagingService.applicationContext)) {
                 notify(notificationFactory.generateNotificationId(), notification)
             }

--- a/plugins/zapp-push-plugin-firebase/manifests/manifest.config.js
+++ b/plugins/zapp-push-plugin-firebase/manifests/manifest.config.js
@@ -265,7 +265,7 @@ const custom_configuration_fields = {
 };
 
 const min_zapp_sdk = {
-  android_for_quickbrick: "0.1.0-alpha1",
+  android_for_quickbrick: "1.1.0-dev",
   ios_for_quickbrick: "2.0.0-Dev",
 };
 


### PR DESCRIPTION
Workaround for https://github.com/Kotlin/kotlinx.coroutines/issues/2041
That occured when SDK Core coroutines library was udpated to lates version to it can pass lint, because old version had another bug.
Coroutines were removed in the problematic place, all work is done in background thread provided by the Firebase.