### PR TITLE
fix: play now events

### DIFF
--- a/plugins/video_playing_now_apple/apple/tvos/ZPAppleVideoNowPlayingInfo+PlayerObserverProtocol.swift
+++ b/plugins/video_playing_now_apple/apple/tvos/ZPAppleVideoNowPlayingInfo+PlayerObserverProtocol.swift
@@ -116,7 +116,7 @@ extension ZPAppleVideoNowPlayingInfo {
             }
 
             // set new value of current stopped position
-            let playbackProgresItem = metadataItem(identifier: AVMetadataIdentifier(rawValue: AVKitMetadataIdentifierPlaybackProgress),
+            let playbackProgresItem = metadataItem(identifier: identifier,
                                                    value: NSNumber(value: roundedProgress))
             metadataItems.append(playbackProgresItem)
 

--- a/plugins/video_playing_now_apple/apple/tvos/ZPAppleVideoNowPlayingInfo+PlayerObserverProtocol.swift
+++ b/plugins/video_playing_now_apple/apple/tvos/ZPAppleVideoNowPlayingInfo+PlayerObserverProtocol.swift
@@ -121,7 +121,6 @@ extension ZPAppleVideoNowPlayingInfo {
             metadataItems.append(playbackProgresItem)
 
             currentItem.externalMetadata = metadataItems
-            print("testAnton \(currentProgress) - \(metadataItems)")
         }
     }
 

--- a/plugins/video_playing_now_apple/apple/tvos/ZPAppleVideoNowPlayingInfo.swift
+++ b/plugins/video_playing_now_apple/apple/tvos/ZPAppleVideoNowPlayingInfo.swift
@@ -10,7 +10,8 @@ import ZappCore
 import AVKit
 
 class ZPAppleVideoNowPlayingInfo: ZPAppleVideoNowPlayingInfoBase {
-
+    var currentProgress: Double = 0
+    
     func metadataItem(identifier : AVMetadataIdentifier, value : (NSCopying & NSObjectProtocol)?) -> AVMetadataItem {
         let item = AVMutableMetadataItem()
         item.value = value


### PR DESCRIPTION
1. Fix support identifiers not only Int -> String and all that support protocol (NSCopying & NSObjectProtocol)
2. Add support if Entry.Extension.isLive use key `AVKitMetadataIdentifierServiceIdentifier`, otherwise `AVKitMetadataIdentifierExternalContentIdentifier`
3. Set progress if Entry.Extension.isLive skip, otherwise use identifier `AVKitMetadataIdentifierPlaybackProgress`
4. Progress will be updated from 0 -> 1 with step 0.01
According documentation: https://help.apple.com/itc/tvpumcstyleguide/#/itc0c92df7c9