### PR TITLE
fix: enable IMA js hook

### DIFF
--- a/plugins/quick-brick-google-ima-apple/manifests/manifest.config.js
+++ b/plugins/quick-brick-google-ima-apple/manifests/manifest.config.js
@@ -8,7 +8,7 @@ const baseManifest = {
     "This plugin allow to add Google Interactive Media Ads to supported players.",
   type: "video_advertisement",
   screen: false,
-  react_native: false,
+  react_native: true,
   ui_builder_support: true,
   whitelisted_account_ids: [
     "572a0a65373163000b000000",


### PR DESCRIPTION
this PR sets the `react-native: true` flag on the plugin manifest.
Leaving this to false prevents the JS hook which grabs the config from the UI builder and passes to the playable item to be installed and run properly.