### PR TITLE
refactor: use new screen hook API

### DIFF
--- a/plugins/quick-brick-apple-user-activity/apple/Universal/Bridge/AppleUserActivityBridge.swift
+++ b/plugins/quick-brick-apple-user-activity/apple/Universal/Bridge/AppleUserActivityBridge.swift
@@ -27,7 +27,7 @@ class AppleUserActivityBridge: NSObject, RCTBridgeModule {
     @objc public func defineUserActivity(_ params: NSDictionary) {
         
         guard let bundleIdentifier = Bundle.main.bundleIdentifier,
-            let contentId = params["apple_umc_show_content_id"] as? String else {
+            let contentId = params["apple_user_activity_content_id"] as? String else {
             return
         }
         

--- a/plugins/quick-brick-apple-user-activity/manifests/manifest.config.js
+++ b/plugins/quick-brick-apple-user-activity/manifests/manifest.config.js
@@ -18,7 +18,6 @@ const baseManifest = {
   min_zapp_sdk: "1.0.0",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
   custom_configuration_fields: [],
   ui_frameworks: ["quickbrick"],
 };

--- a/plugins/quick-brick-apple-user-activity/src/AppleUserActivity.ts
+++ b/plugins/quick-brick-apple-user-activity/src/AppleUserActivity.ts
@@ -1,15 +1,19 @@
-import { playerManager } from "@applicaster/zapp-react-native-utils/appUtils/playerManager";
+import { useNavigation } from "@applicaster/zapp-react-native-utils/reactHooks/navigation";
+
 import { defineUserActivity, removeUserActivity } from "./bridge";
-function cleanUp() {
-  removeUserActivity();
-  playerManager.removeHandler("close", cleanUp);
-}
-export function run(payload, callback) {
-  if (payload?.extensions?.apple_umc_show_content_id) {
-    defineUserActivity({
-      apple_umc_show_content_id: payload?.extensions?.apple_umc_show_content_id,
-    });
-    playerManager.on("close", cleanUp);
-  }
-  callback({ success: true, payload });
+
+export function useScreenHook({ useEffect }) {
+  const { screenData } = useNavigation();
+
+  useEffect(() => {
+    const contentId = screenData?.extensions?.apple_user_activity_content_id;
+
+    if (contentId) {
+      defineUserActivity({ apple_user_activity_content_id: contentId });
+
+      return () => {
+        removeUserActivity();
+      };
+    }
+  });
 }

--- a/plugins/quick-brick-apple-user-activity/src/index.ts
+++ b/plugins/quick-brick-apple-user-activity/src/index.ts
@@ -1,10 +1,7 @@
 /// <reference types=".." />
 
-import { run } from "./AppleUserActivity";
+import { useScreenHook } from "./AppleUserActivity";
 
 export default {
-  hasPlayerHook: true,
-  presentFullScreen: false,
-  isFlowBlocker: false,
-  run,
+  useScreenHook,
 };


### PR DESCRIPTION
this PR refactors the apple user activity feature to rely on the new screen hook API instead of the player hook.

it also changes the name of the extension used for this.

Can be tested with the beta version of the plugin created, and the [version coming soon] canary of QB;
