### PR TITLE
feat: adding support for custom sounds on firebase push notifications

### DIFF
--- a/plugins/zapp-push-plugin-firebase/apple/extensions/service/NotificationService.swift
+++ b/plugins/zapp-push-plugin-firebase/apple/extensions/service/NotificationService.swift
@@ -23,6 +23,12 @@ class NotificationService: UNNotificationServiceExtension {
             return
         }
 
+        // add custom sound param
+        if let sound = content.userInfo["sound"] as? String {
+            let soundName = UNNotificationSoundName(sound)
+            content.sound = UNNotificationSound(named: soundName)
+        }
+
         Messaging.serviceExtension().populateNotificationContent(content, withContentHandler: contentHandler)
     }
     

--- a/plugins/zapp-push-plugin-firebase/manifests/manifest.config.js
+++ b/plugins/zapp-push-plugin-firebase/manifests/manifest.config.js
@@ -64,6 +64,12 @@ const custom_configuration_fields_apple = [
     tooltip_text:
       "Upload Notification Extension Provisioning Profile for Store builds only",
   },
+  {
+    key: "ios_assets_bundle",
+    type: "uploader",
+    label: "Custom sound files",
+    label_tooltip: "Please upload a zip file to provide the custom sounds mp3 files to be used with FCM custom sound parameter</a>."
+  },
 ];
 
 const custom_configuration_fields_android = [


### PR DESCRIPTION
adding support for custom sounds on firebase push notifications

scenarios:
1. parameter not added -> default behaviour
2. parameter added, sound file not exists -> push default sound
3. parameter added, sound file exists -> custom sound

<img width="1229" alt="Screen Shot 2020-12-20 at 16 17 39" src="https://user-images.githubusercontent.com/3462044/102715577-160ca600-42df-11eb-8f29-88e6d08864ac.png">
