### PR TITLE
feat: timing csv sink

### DIFF
--- a/plugins/quick-brick-xray/android/src/main/java/com/applicaster/plugin/xray/TimingSink.kt
+++ b/plugins/quick-brick-xray/android/src/main/java/com/applicaster/plugin/xray/TimingSink.kt
@@ -1,0 +1,67 @@
+package com.applicaster.plugin.xray
+
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+import com.applicaster.util.AppContext
+import com.applicaster.xray.core.Event
+import com.applicaster.xray.core.ISink
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.ConcurrentHashMap
+
+class TimingSink : ISink {
+
+    private var csv: FileOutputStream = FileOutputStream(file)
+
+    private val handler: Handler = Handler(HandlerThread(TAG).apply { start() }.looper)
+
+    init {
+        csv.write("time,total diff,thread name,thread diff,category,subsystem,message\n".toByteArray())
+    }
+
+    @Volatile
+    private var lastTimestamp: Long = System.currentTimeMillis()
+    private val lastThreadTimestamps: ConcurrentHashMap<Long, Long> = ConcurrentHashMap()
+    private val startTimestamp: Long = System.currentTimeMillis()
+
+    override fun log(event: Event) {
+        val now = System.currentTimeMillis()
+        val currentThread = Thread.currentThread()
+        val prev = lastThreadTimestamps.put(currentThread.id, now) ?: lastTimestamp
+        Log.e(Companion.TAG, "s ${now - startTimestamp} a ${now - lastTimestamp} t(${currentThread.name}) ${now - prev} | ${event.category} | ${event.subsystem} | ${event.message.take(45)}")
+        val s = "${now - startTimestamp}," +
+                "${now - lastTimestamp}," +
+                "${currentThread.name}," +
+                "${now - prev}," +
+                "${event.category}," +
+                "${event.subsystem}," +
+                "\"${event.message.take(MSG_LEN).replace("\"", "\"\"")}\"" +
+                "\n"
+        handler.post {
+            csv.write(s.toByteArray())
+            csv.flush()
+        }
+        lastTimestamp = now
+    }
+
+    @Override
+    fun finalize() {
+        // close can be called multiple times
+        close()
+    }
+
+    fun close() {
+        csv.close()
+    }
+
+    companion object {
+        val file: File
+            get() = File(
+                    AppContext.get().getExternalFilesDir(null),
+                    "profile.csv")
+        private const val TAG = "TimingSink"
+        private const val MSG_LEN = 65
+    }
+
+}

--- a/plugins/quick-brick-xray/android/src/main/java/com/applicaster/plugin/xray/XRayPlugin.kt
+++ b/plugins/quick-brick-xray/android/src/main/java/com/applicaster/plugin/xray/XRayPlugin.kt
@@ -178,6 +178,18 @@ class XRayPlugin : CrashlogPlugin {
         // add shortcut
         setupShortcut(true == settings.shortcutEnabled)
 
+        val timingSink = Core.get().getSink("timing")
+        if(true == settings.timingLogging) {
+            if(null == timingSink) {
+                Core.get().addSink("timing", TimingSink())
+            }
+        }
+        else if(null != timingSink) {
+            Core.get().removeSink(timingSink)
+            (timingSink as? TimingSink)?.close()
+            TimingSink.file.delete()
+        }
+
         effectiveSettingsObservable.postValue(settings)
     }
 
@@ -260,7 +272,7 @@ class XRayPlugin : CrashlogPlugin {
             actions[context.resources.getString(R.string.xray_notification_action_send)] = shareLogIntent
         }
 
-        // here we show Notification UI with custom actions
+        // here we show Notification UI with custom agi ctions
         XRayNotification.show(
                 context,
                 notificationId,

--- a/plugins/quick-brick-xray/android/src/main/java/com/applicaster/plugin/xray/XRayPlugin.kt
+++ b/plugins/quick-brick-xray/android/src/main/java/com/applicaster/plugin/xray/XRayPlugin.kt
@@ -272,7 +272,7 @@ class XRayPlugin : CrashlogPlugin {
             actions[context.resources.getString(R.string.xray_notification_action_send)] = shareLogIntent
         }
 
-        // here we show Notification UI with custom agi ctions
+        // here we show Notification UI with custom actions
         XRayNotification.show(
                 context,
                 notificationId,

--- a/plugins/quick-brick-xray/android/src/main/java/com/applicaster/plugin/xray/model/Settings.kt
+++ b/plugins/quick-brick-xray/android/src/main/java/com/applicaster/plugin/xray/model/Settings.kt
@@ -16,6 +16,9 @@ data class Settings(val dummy: Any? = null) {
     // intercept internal react native messages from Printer
     var reactNativeDebugLogging: Boolean? = null
 
+    // enable TimingSink csv output
+    var timingLogging: Boolean? = null
+
     companion object {
         fun merge(base: Settings, overrides: Settings): Settings {
             val merged = base.copy()
@@ -25,6 +28,7 @@ data class Settings(val dummy: Any? = null) {
             merged.showNotification = overrides.showNotification ?: base.showNotification
             merged.reactNativeLogLevel = overrides.reactNativeLogLevel ?: base.reactNativeLogLevel
             merged.reactNativeDebugLogging = overrides.reactNativeDebugLogging ?: base.reactNativeDebugLogging
+            merged.timingLogging = overrides.timingLogging ?: base.timingLogging
             return merged
         }
 

--- a/plugins/quick-brick-xray/android/src/main/res/layout/xray_fragment_settings.xml
+++ b/plugins/quick-brick-xray/android/src/main/res/layout/xray_fragment_settings.xml
@@ -1,101 +1,130 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:padding="16dp"
-    tools:context=".ui.fragements.SettingsFragment">
-
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/switchNotification"
-        style="@style/TextAppearance.AppCompat.Medium"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="16dp"
-        android:text="@string/show_notification"
-        android:textColor="@android:color/black" />
-
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/switchCrashReporting"
-        style="@style/TextAppearance.AppCompat.Medium"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="16dp"
-        android:text="@string/crash_reporting"
-        android:textColor="@android:color/black" />
-
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/switchShortcut"
-        style="@style/TextAppearance.AppCompat.Medium"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="16dp"
-        android:text="@string/shortcut_access"
-        android:textColor="@android:color/black" />
+    android:layout_height="match_parent">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:orientation="horizontal">
+        android:orientation="vertical"
+        android:padding="16dp"
+        tools:context=".ui.fragements.SettingsFragment">
 
-        <TextView
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/switchNotification"
             style="@style/TextAppearance.AppCompat.Medium"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/file_log_level"
+            android:paddingBottom="16dp"
+            android:text="@string/show_notification"
             android:textColor="@android:color/black" />
 
-        <Spinner
-            android:id="@+id/cbFileLogLevel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:orientation="horizontal">
-
-        <TextView
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/switchCrashReporting"
             style="@style/TextAppearance.AppCompat.Medium"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/react_flog_adapter_level"
+            android:paddingBottom="16dp"
+            android:text="@string/crash_reporting"
             android:textColor="@android:color/black" />
 
-        <Spinner
-            android:id="@+id/cbReactLogLevel"
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/switchShortcut"
+            style="@style/TextAppearance.AppCompat.Medium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="16dp"
+            android:text="@string/shortcut_access"
+            android:textColor="@android:color/black" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                style="@style/TextAppearance.AppCompat.Medium"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/file_log_level"
+                android:textColor="@android:color/black" />
+
+            <Spinner
+                android:id="@+id/cbFileLogLevel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                style="@style/TextAppearance.AppCompat.Medium"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/react_flog_adapter_level"
+                android:textColor="@android:color/black" />
+
+            <Spinner
+                android:id="@+id/cbReactLogLevel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <TextView
+            style="@style/TextAppearance.AppCompat.Small"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="16dp"
+            android:text="@string/react_flog_adapter_level_hint"
+            android:textColor="@android:color/black" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/switchReactNativeDebugLogging"
+            style="@style/TextAppearance.AppCompat.Medium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="16dp"
+            android:text="@string/react_native_low_level_logging"
+            android:textColor="@android:color/black" />
+
+        <TextView
+            style="@style/TextAppearance.AppCompat.Small"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="16dp"
+            android:text="@string/react_native_low_level_logging_hint"
+            android:textColor="@android:color/black" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/switchTimingLogging"
+            style="@style/TextAppearance.AppCompat.Medium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="16dp"
+            android:text="@string/xray_timing_logging"
+            android:textColor="@android:color/black" />
+
+        <TextView
+            style="@style/TextAppearance.AppCompat.Small"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/xray_timing_logging_hint"
+            android:textColor="@android:color/black" />
+
+        <Button
+            android:id="@+id/btn_share_timings"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:text="@string/xray_btn_share_timings_as_csv" />
+
     </LinearLayout>
-
-    <TextView
-        style="@style/TextAppearance.AppCompat.Small"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/react_flog_adapter_level_hint"
-        android:textColor="@android:color/black"
-        android:paddingBottom="16dp"/>
-
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/switchReactNativeDebugLogging"
-        style="@style/TextAppearance.AppCompat.Medium"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="16dp"
-        android:text="@string/react_native_low_level_logging"
-        android:textColor="@android:color/black" />
-
-    <TextView
-        style="@style/TextAppearance.AppCompat.Small"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/react_native_low_level_logging_hint"
-        android:textColor="@android:color/black" />
-</LinearLayout>
+</ScrollView>

--- a/plugins/quick-brick-xray/android/src/main/res/values/strings.xml
+++ b/plugins/quick-brick-xray/android/src/main/res/values/strings.xml
@@ -9,4 +9,7 @@
     <string name="xray_shortcut_label">Open X-Ray log</string>
     <string name="xray_notification_action_show">Show</string>
     <string name="xray_notification_action_send">Send</string>
+    <string name="xray_timing_logging">Timings logging</string>
+    <string name="xray_timing_logging_hint">Log time passed before each next message logged to CSV file.</string>
+    <string name="xray_btn_share_timings_as_csv">Share timings as CSV</string>
 </resources>


### PR DESCRIPTION
Added an option to share csv file with log messages intervals right away from the app.
This allow convenient flow to basic load time profiling:

- enable the timing logging sink
- restart the app to obtain new data
- go to xray screen and use Share button to send data to the gmail (Google Drive is not smart enough to import csv file as sheets). The file is also available on the SD card directly in the application Files directory, for example /sdcard/Android/data/com.applicaster.miamiheat/files/profile.csv.
- in gmail, file can be checked right away as a preview, or exported to Google Sheets for advanced filtering

While it does not provide timings for every operation, as stopwatch type of timing would do (we see how much time has passed before current line was logged, not time taken by the log entry operation), it still gives enough information, especially if thread name or id filter is applied.

![image](https://user-images.githubusercontent.com/24409942/103548503-e4b1df80-4e73-11eb-8f79-d06267083d8a.png)

![Screen Shot 2021-01-04 at 10 03 43](https://user-images.githubusercontent.com/24409942/103548659-22af0380-4e74-11eb-801a-e08c5cd3a6d4.png)

