### PR TITLE
fix: Pause player before going to fetch the preroll (if preroll exists)

### DIFF
--- a/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
+++ b/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
@@ -40,6 +40,9 @@ import ZappCore
     var isPrerollAdLoading = false {
         didSet {
             showActivityIndicator(isPrerollAdLoading)
+            if isPrerollAdLoading {
+                pausePlayback()
+            }
         }
     }
     /// Player plugin instance that currently presented


### PR DESCRIPTION
Pause player before going to fetch the preroll (if preroll exists)