### PR TITLE
feat: Adding readyToPlay function to the player + Changes in IMA to use it for ads before playback

### DIFF
--- a/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter+QBPlayerObserverProtocol.swift
+++ b/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter+QBPlayerObserverProtocol.swift
@@ -68,5 +68,6 @@ extension GoogleInteractiveMediaAdsAdapter: PlayerObserverProtocol {
     }
 
     public func playerDidCreate(player: PlayerProtocol) {
+        updatePresentationOfActivityIndicatorIfNeeded()
     }
 }

--- a/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter+QBPlayerObserverProtocol.swift
+++ b/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter+QBPlayerObserverProtocol.swift
@@ -13,7 +13,7 @@ extension GoogleInteractiveMediaAdsAdapter: PlayerObserverProtocol {
     public func playerReadyToPlay(player: PlayerProtocol) -> Bool {
         return prepareGoogleIMA()
     }
-    
+
     public func playerDidFinishPlayItem(player: PlayerProtocol,
                                         completion: @escaping (_ finished: Bool) -> Void) {
         adsLoader?.contentComplete()
@@ -46,12 +46,12 @@ extension GoogleInteractiveMediaAdsAdapter: PlayerObserverProtocol {
             requestAd(adUrl: postrollUrl)
         }
     }
-    
+
     public func playerProgressUpdate(player: PlayerProtocol,
                                      currentTime: TimeInterval,
                                      duration: TimeInterval) {
         if let currentVideoTime = playerPlugin?.playbackPosition(),
-            let url = urlTagData?.requestMiddroll(currentVideoTime: currentVideoTime) {
+           let url = urlTagData?.requestMiddroll(currentVideoTime: currentVideoTime) {
             requestAd(adUrl: url)
         }
     }
@@ -68,6 +68,5 @@ extension GoogleInteractiveMediaAdsAdapter: PlayerObserverProtocol {
     }
 
     public func playerDidCreate(player: PlayerProtocol) {
-
     }
 }

--- a/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter+QBPlayerObserverProtocol.swift
+++ b/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter+QBPlayerObserverProtocol.swift
@@ -10,6 +10,10 @@ import Foundation
 import ZappCore
 
 extension GoogleInteractiveMediaAdsAdapter: PlayerObserverProtocol {
+    public func playerReadyToPlay(player: PlayerProtocol) -> Bool {
+        return prepareGoogleIMA()
+    }
+    
     public func playerDidFinishPlayItem(player: PlayerProtocol,
                                         completion: @escaping (_ finished: Bool) -> Void) {
         adsLoader?.contentComplete()
@@ -64,6 +68,6 @@ extension GoogleInteractiveMediaAdsAdapter: PlayerObserverProtocol {
     }
 
     public func playerDidCreate(player: PlayerProtocol) {
-        prepareGoogleIMA()
+
     }
 }

--- a/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
+++ b/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
@@ -67,11 +67,12 @@ import ZappCore
 
     var urlTagData: GoogleUrlTagData?
 
-    func prepareGoogleIMA() {
+    func prepareGoogleIMA() -> Bool {
+        var completed = true
         isPlaybackPaused = false
         isVMAPAdsCompleted = false
         isPrerollAdLoading = false
-        guard let player = avPlayer else { return }
+        guard let player = avPlayer else { return completed }
         addNotificationsObserver()
         addRateObserver()
         
@@ -81,13 +82,14 @@ import ZappCore
 
         if let urlToPresent = urlTagData?.prerollUrlString() {
             isPrerollAdLoading = true
-            
+            completed = false
             GoogleInteractiveMediaAdsAdapterTrackingIdentifier.requestTrackingAuthorization {
                 DispatchQueue.main.async {
                     self.requestAd(adUrl: urlToPresent)
                 }
             }
         }
+        return completed
     }
 
     func addNotificationsObserver() {

--- a/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
+++ b/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
@@ -69,11 +69,11 @@ import ZappCore
     var urlTagData: GoogleUrlTagData?
 
     func prepareGoogleIMA() -> Bool {
-        var completed = true
+        var shouldContinuePlaying = true
         isPlaybackPaused = false
         isVMAPAdsCompleted = false
         isPrerollAdLoading = false
-        guard let player = avPlayer else { return completed }
+        guard let player = avPlayer else { return shouldContinuePlaying }
         addNotificationsObserver()
         addRateObserver()
 
@@ -83,14 +83,14 @@ import ZappCore
 
         if let urlToPresent = urlTagData?.prerollUrlString() {
             isPrerollAdLoading = true
-            completed = false
+            shouldContinuePlaying = false
             GoogleInteractiveMediaAdsAdapterTrackingIdentifier.requestTrackingAuthorization {
                 DispatchQueue.main.async {
                     self.requestAd(adUrl: urlToPresent)
                 }
             }
         }
-        return completed
+        return shouldContinuePlaying
     }
 
     func addNotificationsObserver() {

--- a/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
+++ b/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
@@ -39,7 +39,7 @@ import ZappCore
     var isPlaybackPaused = false
     var isPrerollAdLoading = false {
         didSet {
-            showActivityIndicator(isPrerollAdLoading)
+            updatePresentationOfActivityIndicatorIfNeeded()
         }
     }
 
@@ -145,20 +145,29 @@ import ZappCore
         }
     }
 
-    func showActivityIndicator(_ show: Bool) {
-        if show {
-            guard let contentOverlay = (playerPlugin?.pluginPlayerViewController as? AVPlayerViewController)?.contentOverlayView else {
-                return
-            }
-            contentOverlay.addSubview(activityIndicator)
-            activityIndicator.startAnimating()
+    func updatePresentationOfActivityIndicatorIfNeeded() {
+        if isPrerollAdLoading {
             activityIndicator.color = .gray
             activityIndicator.backgroundColor = .black
-            activityIndicator.widthAnchor.constraint(equalTo: contentOverlay.widthAnchor, multiplier: 1.0).isActive = true
-            activityIndicator.heightAnchor.constraint(equalTo: contentOverlay.heightAnchor, multiplier: 1.0).isActive = true
-            activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+            
+            if let contentOverlay = (self.playerPlugin?.pluginPlayerViewController as? AVPlayerViewController)?.contentOverlayView,
+               self.activityIndicator.superview == nil {
+                contentOverlay.addSubview(self.activityIndicator)
+                activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+                activityIndicator.widthAnchor.constraint(equalTo: contentOverlay.widthAnchor, multiplier: 1.0).isActive = true
+                activityIndicator.heightAnchor.constraint(equalTo: contentOverlay.heightAnchor, multiplier: 1.0).isActive = true
+                activityIndicator.startAnimating()
+            }
+            else if let playerView = self.playerPlugin as? UIView,
+                    let playerLayer = playerView.layer.sublayers?.first(where: { $0 is AVPlayerLayer}) {
+                activityIndicator.frame = playerLayer.bounds
+                playerLayer.addSublayer(activityIndicator.layer)
+                activityIndicator.startAnimating()
+            }
+
         } else {
-            activityIndicator.removeFromSuperview()
+            self.activityIndicator.removeFromSuperview()
+            self.activityIndicator.layer.removeFromSuperlayer()
         }
     }
 

--- a/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
+++ b/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
@@ -42,6 +42,7 @@ import ZappCore
             showActivityIndicator(isPrerollAdLoading)
         }
     }
+
     /// Player plugin instance that currently presented
     public weak var playerPlugin: PlayerProtocol?
     var postrollCompletion: ((_ finished: Bool) -> Void)?
@@ -56,9 +57,9 @@ import ZappCore
 
     /// Main point of interaction with the SDK. Created by the SDK as the result of an ad request.
     internal var adsManager: IMAAdsManager?
-    
+
     internal var adDisplayContainer: IMAAdDisplayContainer?
-    
+
     internal var advAccessibilityIdentifier: String?
 
     var avPlayer: AVPlayer? {
@@ -75,7 +76,7 @@ import ZappCore
         guard let player = avPlayer else { return completed }
         addNotificationsObserver()
         addRateObserver()
-        
+
         urlTagData = GoogleUrlTagData(entry: playerPlugin?.entry,
                                       pluginParams: configurationJSON)
         contentPlayhead = IMAAVPlayerContentPlayhead(avPlayer: player)
@@ -94,56 +95,56 @@ import ZappCore
 
     func addNotificationsObserver() {
         let defaultCenter = NotificationCenter.default
-        
+
         defaultCenter.addObserver(self,
-                                  selector: #selector(self.applicationWillResignActive(notification:)),
+                                  selector: #selector(applicationWillResignActive(notification:)),
                                   name: UIApplication.willResignActiveNotification,
                                   object: nil)
-        
+
         defaultCenter.addObserver(self,
-                                  selector: #selector(self.applicationDidBecomeActive(notification:)),
+                                  selector: #selector(applicationDidBecomeActive(notification:)),
                                   name: UIApplication.didBecomeActiveNotification,
                                   object: nil)
     }
-    
-    @objc func applicationWillResignActive(notification:Notification) {
+
+    @objc func applicationWillResignActive(notification: Notification) {
         adsManager?.pause()
     }
-    
-    @objc func applicationDidBecomeActive(notification:Notification) {
+
+    @objc func applicationDidBecomeActive(notification: Notification) {
         adsManager?.resume()
     }
 
     func addRateObserver() {
         avPlayer?.addObserver(self, forKeyPath: MediaAdsConstants.playerPlaybackRate, options: NSKeyValueObservingOptions.new, context: nil)
     }
-    
-    override public func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+
+    override public func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         if keyPath == MediaAdsConstants.playerPlaybackRate {
             if let player = avPlayer, player.rate > 0 && isPlaybackPaused {
                 avPlayer?.pause()
             }
         }
     }
-    
+
     func resumePlayback() {
         isPlaybackPaused = false
         playerPlugin?.pluggablePlayerResume()
-        
+
         if adDisplayContainer == adDisplayContainer {
             adDisplayContainer?.adContainer.accessibilityIdentifier = ""
         }
     }
-    
+
     func pausePlayback() {
         isPlaybackPaused = true
         playerPlugin?.pluggablePlayerPause()
-        
+
         if adDisplayContainer == adDisplayContainer {
             adDisplayContainer?.adContainer.accessibilityIdentifier = advAccessibilityIdentifier
         }
     }
-    
+
     func showActivityIndicator(_ show: Bool) {
         if show {
             guard let contentOverlay = (playerPlugin?.pluginPlayerViewController as? AVPlayerViewController)?.contentOverlayView else {
@@ -160,7 +161,7 @@ import ZappCore
             activityIndicator.removeFromSuperview()
         }
     }
-    
+
     func setupAdsLoader() {
         let settings = IMASettings()
         settings.enableDebugMode = false
@@ -176,14 +177,13 @@ import ZappCore
         setupAdsLoader()
 
         #if os(tvOS)
-        adDisplayContainer = IMAAdDisplayContainer(adContainer: topViewController.view,
-                                                   viewController: topViewController)
+            adDisplayContainer = IMAAdDisplayContainer(adContainer: topViewController.view,
+                                                       viewController: topViewController)
         #else
-        
 
-        adDisplayContainer = IMAAdDisplayContainer(adContainer: topViewController.view,
-                                                   viewController: topViewController,
-                                                   companionSlots: nil)
+            adDisplayContainer = IMAAdDisplayContainer(adContainer: topViewController.view,
+                                                       viewController: topViewController,
+                                                       companionSlots: nil)
         #endif
         if let request = IMAAdsRequest(adTagUrl: adUrl,
                                        adDisplayContainer: adDisplayContainer,
@@ -191,7 +191,7 @@ import ZappCore
                                        userContext: nil) {
             adRequest = request
             adsLoader?.requestAds(with: adRequest)
-            
+
             // Storing accessibility identifier for UI automation tests needs
             advAccessibilityIdentifier = adUrl
         }

--- a/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
+++ b/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
@@ -40,9 +40,6 @@ import ZappCore
     var isPrerollAdLoading = false {
         didSet {
             showActivityIndicator(isPrerollAdLoading)
-            if isPrerollAdLoading {
-                pausePlayback()
-            }
         }
     }
     /// Player plugin instance that currently presented

--- a/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
+++ b/plugins/quick-brick-google-ima-apple/apple/universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
@@ -37,10 +37,9 @@ import ZappCore
     var activityIndicator = UIActivityIndicatorView()
     var isVMAPAdsCompleted = false
     var isPlaybackPaused = false
-    var shouldPresentActivityIndicator = false
     var isPrerollAdLoading = false {
         didSet {
-            shouldPresentActivityIndicator = isPrerollAdLoading
+            showActivityIndicator(isPrerollAdLoading)
             if isPrerollAdLoading {
                 pausePlayback()
             }
@@ -132,18 +131,12 @@ import ZappCore
         isPlaybackPaused = false
         playerPlugin?.pluggablePlayerResume()
         
-        //removing the activity indicator after resuming the playback to avoid blickering of info overlay
-        DispatchQueue.main.async {
-            self.updatePresentationOfActivityIndicator()
-        }
-
         if adDisplayContainer == adDisplayContainer {
             adDisplayContainer?.adContainer.accessibilityIdentifier = ""
         }
     }
     
     func pausePlayback() {
-        updatePresentationOfActivityIndicator()
         isPlaybackPaused = true
         playerPlugin?.pluggablePlayerPause()
         
@@ -152,8 +145,8 @@ import ZappCore
         }
     }
     
-    func updatePresentationOfActivityIndicator() {
-        if shouldPresentActivityIndicator {
+    func showActivityIndicator(_ show: Bool) {
+        if show {
             guard let contentOverlay = (playerPlugin?.pluginPlayerViewController as? AVPlayerViewController)?.contentOverlayView else {
                 return
             }

--- a/plugins/quick-brick-google-ima-apple/manifests/manifest.config.js
+++ b/plugins/quick-brick-google-ima-apple/manifests/manifest.config.js
@@ -77,8 +77,8 @@ function createManifest({ version, platform }) {
   return manifest;
 }
 const min_zapp_sdk = {
-  tvos_for_quickbrick: "2.0.2-Dev",
-  ios_for_quickbrick: "2.0.2-Dev"
+  tvos_for_quickbrick: "4.0.0-Dev",
+  ios_for_quickbrick: "4.0.0-Dev"
 };
 
 const extra_dependencies_apple = {

--- a/plugins/zapp-apple/apple/universal/Plugins/PlayerDependant/PlayerDependantPluginsManager+PlayerObserverProtocol.swift
+++ b/plugins/zapp-apple/apple/universal/Plugins/PlayerDependant/PlayerDependantPluginsManager+PlayerObserverProtocol.swift
@@ -67,8 +67,11 @@ extension PlayerDependantPluginsManager: PlayerObserverProtocol {
         if let providers = providers(playerPlugin: player) {
             providers.forEach { providerDict in
                 let provider = providerDict.value
-                if let provider = provider as? PlayerObserverProtocol {
-                    shouldContinuePlaying = provider.playerReadyToPlay?(player: player) ?? true
+                if let provider = provider as? PlayerObserverProtocol,
+                   let value = provider.playerReadyToPlay?(player: player),
+                   value == false {
+                    //update only if false as player dependent plugins may have different value and we need single false to stop playback
+                    shouldContinuePlaying = value
                 }
             }
         }
@@ -89,6 +92,15 @@ extension PlayerDependantPluginsManager: PlayerObserverProtocol {
 
     public func playerDidCreate(player: PlayerProtocol) {
         createProvidersIfNeeded(with: player)
+        
+        if let providersForPlayer = providers(playerPlugin: player) {
+            providersForPlayer.forEach { providerDict in
+                let provider = providerDict.value
+                if let provider = provider as? PlayerObserverProtocol {
+                    provider.playerDidCreate(player: player)
+                }
+            }
+        }
     }
 
     private func createProvidersIfNeeded(with player: PlayerProtocol) {

--- a/plugins/zapp-apple/apple/universal/Plugins/PlayerDependant/PlayerDependantPluginsManager+PlayerObserverProtocol.swift
+++ b/plugins/zapp-apple/apple/universal/Plugins/PlayerDependant/PlayerDependantPluginsManager+PlayerObserverProtocol.swift
@@ -69,7 +69,7 @@ extension PlayerDependantPluginsManager: PlayerObserverProtocol {
             providers.forEach { providerDict in
                 let provider = providerDict.value
                 if let provider = provider as? PlayerObserverProtocol {
-                    shouldContinuePlaying = provider.playerReadyToPlay(player: player)
+                    shouldContinuePlaying = provider.playerReadyToPlay?(player: player) ?? true
                 }
             }
         }

--- a/plugins/zapp-apple/apple/universal/Plugins/PlayerDependant/PlayerDependantPluginsManager+PlayerObserverProtocol.swift
+++ b/plugins/zapp-apple/apple/universal/Plugins/PlayerDependant/PlayerDependantPluginsManager+PlayerObserverProtocol.swift
@@ -53,19 +53,16 @@ extension PlayerDependantPluginsManager: PlayerObserverProtocol {
     }
 
     public func playerReadyToPlay(player: PlayerProtocol) -> Bool {
+        // provider can prevent from starting to play when player is ready to play
+        // provider should call player.pluggablePlayerResume() when finished its operations
+        var shouldContinuePlaying = false
+
         // should continue on first iteration when providers are not yet created
         guard providers(playerPlugin: player) == nil else {
             return false
         }
 
-        unRegisterProviders(playerPlugin: player)
-        let dependantPlayerProviders = createPlayerDependantProviders(for: player)
-        if dependantPlayerProviders.count > 0 {
-            providers["\(player.hash)"] = dependantPlayerProviders
-        }
-
-        playerDidCreate(player: player)
-        var shouldContinuePlaying = false
+        createProvidersIfNeeded(with: player)
 
         if let providers = providers(playerPlugin: player) {
             shouldContinuePlaying = true
@@ -92,5 +89,21 @@ extension PlayerDependantPluginsManager: PlayerObserverProtocol {
     }
 
     public func playerDidCreate(player: PlayerProtocol) {
+        createProvidersIfNeeded(with: player)
+    }
+
+    private func createProvidersIfNeeded(with player: PlayerProtocol) {
+        // should continue on first iteration when providers are not yet created
+        guard providers(playerPlugin: player) == nil else {
+            return
+        }
+
+        unRegisterProviders(playerPlugin: player)
+
+        let dependantPlayerProviders = createPlayerDependantProviders(for: player)
+
+        if dependantPlayerProviders.count > 0 {
+            providers["\(player.hash)"] = dependantPlayerProviders
+        }
     }
 }

--- a/plugins/zapp-apple/apple/universal/Plugins/PlayerDependant/PlayerDependantPluginsManager+PlayerObserverProtocol.swift
+++ b/plugins/zapp-apple/apple/universal/Plugins/PlayerDependant/PlayerDependantPluginsManager+PlayerObserverProtocol.swift
@@ -55,17 +55,16 @@ extension PlayerDependantPluginsManager: PlayerObserverProtocol {
     public func playerReadyToPlay(player: PlayerProtocol) -> Bool {
         // provider can prevent from starting to play when player is ready to play
         // provider should call player.pluggablePlayerResume() when finished its operations
-        var shouldContinuePlaying = false
+        var shouldContinuePlaying = true
 
         // should continue on first iteration when providers are not yet created
         guard providers(playerPlugin: player) == nil else {
-            return false
+            return shouldContinuePlaying
         }
 
         createProvidersIfNeeded(with: player)
 
         if let providers = providers(playerPlugin: player) {
-            shouldContinuePlaying = true
             providers.forEach { providerDict in
                 let provider = providerDict.value
                 if let provider = provider as? PlayerObserverProtocol {

--- a/plugins/zapp-apple/apple/universal/Plugins/PlayerDependant/PlayerDependantPluginsManager+PlayerObserverProtocol.swift
+++ b/plugins/zapp-apple/apple/universal/Plugins/PlayerDependant/PlayerDependantPluginsManager+PlayerObserverProtocol.swift
@@ -69,7 +69,7 @@ extension PlayerDependantPluginsManager: PlayerObserverProtocol {
             providers.forEach { providerDict in
                 let provider = providerDict.value
                 if let provider = provider as? PlayerObserverProtocol {
-                    shouldContinuePlaying = provider.playerReadyToPlay?(player: player) ?? true
+                    shouldContinuePlaying = provider.playerReadyToPlay(player: player)
                 }
             }
         }

--- a/plugins/zapp-apple/apple/universal/Plugins/PlayerDependant/PlayerDependantPluginsManager.swift
+++ b/plugins/zapp-apple/apple/universal/Plugins/PlayerDependant/PlayerDependantPluginsManager.swift
@@ -54,7 +54,6 @@ import XrayLogger
                 //add provider if created or found in already created instances
                 if let provider = provider {
                     provider.playerPlugin = player
-                    provider.playerDidCreate(player: player)
                     retVal[pluginModel.identifier] = provider
                 }
             }

--- a/plugins/zapp-apple/apple/universal/RootController/FacadeConnector/RootController+FacadeConnectorPlayerDependantProtocol.swift
+++ b/plugins/zapp-apple/apple/universal/RootController/FacadeConnector/RootController+FacadeConnectorPlayerDependantProtocol.swift
@@ -11,7 +11,7 @@ import ZappCore
 
 extension RootController: FacadeConnectorPlayerDependantProtocol {
     public func playerDidFinishPlayItem(player: PlayerProtocol,
-                                 completion: @escaping (Bool) -> Void) {
+                                        completion: @escaping (Bool) -> Void) {
         pluginsManager.playerDependants.playerDidFinishPlayItem(player: player,
                                                                 completion: completion)
     }
@@ -25,30 +25,34 @@ extension RootController: FacadeConnectorPlayerDependantProtocol {
     }
 
     public func playerProgressUpdate(player: PlayerProtocol,
-                              currentTime: TimeInterval,
-                              duration: TimeInterval) {
+                                     currentTime: TimeInterval,
+                                     duration: TimeInterval) {
         pluginsManager.playerDependants.playerProgressUpdate(player: player,
                                                              currentTime: currentTime,
                                                              duration: duration)
     }
-    
+
+    public func playerReadyToPlay(player: PlayerProtocol) -> Bool {
+        return pluginsManager.playerDependants.playerReadyToPlay(player: player)
+    }
+
     public func playerAdStarted(player: PlayerProtocol) {
-             pluginsManager.playerDependants.playerAdStarted(player: player)
+        pluginsManager.playerDependants.playerAdStarted(player: player)
     }
-       
+
     public func playerAdCompleted(player: PlayerProtocol) {
-         pluginsManager.playerDependants.playerAdCompleted(player: player)
+        pluginsManager.playerDependants.playerAdCompleted(player: player)
     }
-   
+
     public func playerAdSkiped(player: PlayerProtocol) {
-         pluginsManager.playerDependants.playerAdSkiped(player: player)
+        pluginsManager.playerDependants.playerAdSkiped(player: player)
     }
-   
+
     public func playerAdProgressUpdate(player: PlayerProtocol,
                                        currentTime: TimeInterval,
                                        duration: TimeInterval) {
-         pluginsManager.playerDependants.playerAdProgressUpdate(player: player,
-                                                              currentTime: currentTime,
-                                                              duration: duration)
+        pluginsManager.playerDependants.playerAdProgressUpdate(player: player,
+                                                               currentTime: currentTime,
+                                                               duration: duration)
     }
 }

--- a/plugins/zapp-core/apple/universal/Plugins/Player/PlayerObserverProtocol.swift
+++ b/plugins/zapp-core/apple/universal/Plugins/Player/PlayerObserverProtocol.swift
@@ -37,4 +37,9 @@ import Foundation
     func playerProgressUpdate(player: PlayerProtocol,
                               currentTime: TimeInterval,
                               duration: TimeInterval)
+
+    /// Player instance is ready to play
+    ///
+    ///  - player: instance of the player that conform PlayerProtocol protocol
+    func playerReadyToPlay(player: PlayerProtocol) -> Bool
 }

--- a/plugins/zapp-core/apple/universal/Plugins/Player/PlayerObserverProtocol.swift
+++ b/plugins/zapp-core/apple/universal/Plugins/Player/PlayerObserverProtocol.swift
@@ -41,5 +41,5 @@ import Foundation
     /// Player instance is ready to play
     ///
     ///  - player: instance of the player that conform PlayerProtocol protocol
-    func playerReadyToPlay(player: PlayerProtocol) -> Bool
+    @objc optional func playerReadyToPlay(player: PlayerProtocol) -> Bool
 }

--- a/plugins/zapp-core/apple/universal/Plugins/Player/PlayerObserverProtocol.swift
+++ b/plugins/zapp-core/apple/universal/Plugins/Player/PlayerObserverProtocol.swift
@@ -41,5 +41,5 @@ import Foundation
     /// Player instance is ready to play
     ///
     ///  - player: instance of the player that conform PlayerProtocol protocol
-    @objc optional func playerReadyToPlay(player: PlayerProtocol) -> Bool
+    func playerReadyToPlay(player: PlayerProtocol) -> Bool
 }


### PR DESCRIPTION
1. Adding readyToPlay function to the connector to perform changes on the player dependent plugins before starting to play
2. Changes in IMA to use it for ads before playback

@kononenkoAnton  this is instead of moving the IMA into the player because of IDFA usage in IMA which should not be a part of default implementation as it could be used by kids apps