### PR TITLE
feat: disable preload hook flag for plugins that do not need it

### DIFF
--- a/plugins/quick-brick-xray/manifests/manifest.config.js
+++ b/plugins/quick-brick-xray/manifests/manifest.config.js
@@ -17,7 +17,7 @@ const baseManifest = {
   min_zapp_sdk: "0.0.1",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],

--- a/plugins/zapp-analytics-plugin-adobe/manifests/manifest.config.js
+++ b/plugins/zapp-analytics-plugin-adobe/manifests/manifest.config.js
@@ -17,7 +17,7 @@ const baseManifest = {
   min_zapp_sdk: "1.0.0",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],

--- a/plugins/zapp-analytics-plugin-akamai/manifests/manifest.config.js
+++ b/plugins/zapp-analytics-plugin-akamai/manifests/manifest.config.js
@@ -17,7 +17,7 @@ const baseManifest = {
   min_zapp_sdk: "1.0.0",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],

--- a/plugins/zapp-analytics-plugin-appsflyer/manifests/manifest.config.js
+++ b/plugins/zapp-analytics-plugin-appsflyer/manifests/manifest.config.js
@@ -14,7 +14,7 @@ const baseManifest = {
   min_zapp_sdk: "1.0.0",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],

--- a/plugins/zapp-analytics-plugin-chartbeat/manifests/manifest.config.js
+++ b/plugins/zapp-analytics-plugin-chartbeat/manifests/manifest.config.js
@@ -17,7 +17,7 @@ const baseManifest = {
   min_zapp_sdk: "1.0.0",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],

--- a/plugins/zapp-analytics-plugin-comscore/manifests/manifest.config.js
+++ b/plugins/zapp-analytics-plugin-comscore/manifests/manifest.config.js
@@ -17,7 +17,7 @@ const baseManifest = {
   min_zapp_sdk: "1.0.0",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],

--- a/plugins/zapp-analytics-plugin-cooladata/manifests/manifest.config.js
+++ b/plugins/zapp-analytics-plugin-cooladata/manifests/manifest.config.js
@@ -17,7 +17,7 @@ const baseManifest = {
   min_zapp_sdk: "1.0.0",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],

--- a/plugins/zapp-analytics-plugin-firebase/manifests/manifest.config.js
+++ b/plugins/zapp-analytics-plugin-firebase/manifests/manifest.config.js
@@ -17,7 +17,7 @@ const baseManifest = {
   min_zapp_sdk: "0.0.1",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],

--- a/plugins/zapp-analytics-plugin-google/manifests/manifest.config.js
+++ b/plugins/zapp-analytics-plugin-google/manifests/manifest.config.js
@@ -14,7 +14,7 @@ const baseManifest = {
   min_zapp_sdk: "2.0.0",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],

--- a/plugins/zapp-analytics-plugin-mixpanel/manifests/manifest.config.js
+++ b/plugins/zapp-analytics-plugin-mixpanel/manifests/manifest.config.js
@@ -17,7 +17,7 @@ const baseManifest = {
   min_zapp_sdk: "1.0.0",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],

--- a/plugins/zapp-push-plugin-firebase/manifests/manifest.config.js
+++ b/plugins/zapp-push-plugin-firebase/manifests/manifest.config.js
@@ -20,7 +20,7 @@ const baseManifest = {
   min_zapp_sdk: "0.0.1",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],

--- a/plugins/zapp_local_notifications/manifests/manifest.config.js
+++ b/plugins/zapp_local_notifications/manifests/manifest.config.js
@@ -14,7 +14,7 @@ const baseManifest = {
   min_zapp_sdk: "0.0.1",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],

--- a/templates/manifests/manifest.config.js
+++ b/templates/manifests/manifest.config.js
@@ -12,7 +12,7 @@ const baseManifest = {
   min_zapp_sdk: "0.0.1",
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
-  preload: true,
+  preload: false,
   custom_configuration_fields: [],
   targets: ["mobile"],
   ui_frameworks: ["quickbrick"],


### PR DESCRIPTION
We have a flag telling that the plugin is a hook enabled for plugins that are not hooks.
Template manifest was updated for convenience.