### PR TITLE
feat: add logs and proguard rules to in-app purchasees

### DIFF
--- a/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/IAPBridge.kt
+++ b/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/IAPBridge.kt
@@ -1,8 +1,8 @@
 package com.applicaster.iap.reactnative
 
-import android.util.Log
 import com.applicaster.iap.reactnative.utils.*
 import com.applicaster.iap.uni.api.*
+import com.applicaster.util.APLogger
 import com.facebook.react.bridge.*
 
 
@@ -54,14 +54,15 @@ class IAPBridge(reactContext: ReactApplicationContext)
 
     @ReactMethod
     fun initialize(vendor: String, result: Promise) {
+        APLogger.debug(TAG, "Initializing Billing client for $vendor")
         api = IBillingAPI.create(IBillingAPI.Vendor.valueOf(vendor))
         api.init(reactApplicationContext, object : InitializationListener {
             override fun onSuccess() {
-                Log.d(TAG, "Billing client initialized")
+                APLogger.debug(TAG, "Billing client initialized")
                 result.resolve(true)
             }
             override fun onBillingClientError(billingResult: IBillingAPI.IAPResult, description: String) {
-                Log.e(TAG, "Billing client initialization failed $description")
+                APLogger.error(TAG, "Billing client initialization failed $description")
                 result.reject(billingResult.toString(), description)
             }
         })

--- a/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/AcknowledgePromiseListener.kt
+++ b/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/AcknowledgePromiseListener.kt
@@ -1,13 +1,13 @@
 package com.applicaster.iap.reactnative.utils
 
-import android.util.Log
 import com.applicaster.iap.reactnative.IAPBridge
+import com.applicaster.util.APLogger
 import com.facebook.react.bridge.Promise
 
 class AcknowledgePromiseListener(promise: Promise) : PromiseListener(promise) {
 
     override fun onPurchaseAcknowledged() {
-        Log.d(IAPBridge.TAG, "Purchases was acknowledged.")
+        APLogger.debug(IAPBridge.TAG, "Purchases was acknowledged.")
         promise.resolve(true)
     }
 

--- a/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/ConsumePromiseListener.kt
+++ b/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/ConsumePromiseListener.kt
@@ -1,13 +1,13 @@
 package com.applicaster.iap.reactnative.utils
 
-import android.util.Log
 import com.applicaster.iap.reactnative.IAPBridge
+import com.applicaster.util.APLogger
 import com.facebook.react.bridge.Promise
 
 class ConsumePromiseListener(promise: Promise) : PromiseListener(promise) {
 
     override fun onPurchaseConsumed(purchaseToken: String) {
-        Log.d(IAPBridge.TAG, "Purchases was consumed.")
+        APLogger.debug(IAPBridge.TAG, "Purchases was consumed.")
         promise.resolve(purchaseToken)
     }
 }

--- a/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/FinishingPurchasePromiseListener.kt
+++ b/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/FinishingPurchasePromiseListener.kt
@@ -1,9 +1,9 @@
 package com.applicaster.iap.reactnative.utils
 
-import android.util.Log
 import com.applicaster.iap.reactnative.IAPBridge
 import com.applicaster.iap.uni.api.IBillingAPI
 import com.applicaster.iap.uni.api.Purchase
+import com.applicaster.util.APLogger
 import com.facebook.react.bridge.Promise
 
 class FinishingPurchasePromiseListener(bridge: IAPBridge,
@@ -15,7 +15,7 @@ class FinishingPurchasePromiseListener(bridge: IAPBridge,
     private lateinit var purchase: Purchase
 
     override fun onPurchased(purchase: Purchase) {
-        Log.d(IAPBridge.TAG, "Finishing transaction for $sku.")
+        APLogger.debug(IAPBridge.TAG, "Finishing transaction for $sku.")
         this.purchase = fix(purchase)
         bridge.acknowledge(
                 sku,
@@ -25,12 +25,12 @@ class FinishingPurchasePromiseListener(bridge: IAPBridge,
     }
 
     override fun onPurchaseConsumed(purchaseToken: String) {
-        Log.d(IAPBridge.TAG, "Transaction for $sku was finished.")
+        APLogger.debug(IAPBridge.TAG, "Transaction for $sku was finished.")
         promise.resolve(wrap(purchase))
     }
 
     override fun onPurchaseAcknowledged() {
-        Log.d(IAPBridge.TAG, "Failed to finish transaction for $sku.")
+        APLogger.debug(IAPBridge.TAG, "Failed to finish transaction for $sku.")
         promise.resolve(wrap(purchase))
     }
 }

--- a/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/PromiseListener.kt
+++ b/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/PromiseListener.kt
@@ -1,12 +1,12 @@
 package com.applicaster.iap.reactnative.utils
 
 
-import android.util.Log
 import com.applicaster.iap.reactnative.IAPBridge
 import com.applicaster.iap.uni.api.IAPListener
 import com.applicaster.iap.uni.api.IBillingAPI
 import com.applicaster.iap.uni.api.Purchase
 import com.applicaster.iap.uni.api.Sku
+import com.applicaster.util.APLogger
 import com.facebook.react.bridge.Promise
 
 abstract class PromiseListener(protected val promise: Promise) : IAPListener {
@@ -40,7 +40,7 @@ abstract class PromiseListener(protected val promise: Promise) : IAPListener {
             reportError("PurchaseAcknowledge", result, description)
 
     private fun reportError(operation: String, result: IBillingAPI.IAPResult, description: String) {
-        Log.e(IAPBridge.TAG, "$operation failed with result $result: $description")
+        APLogger.error(IAPBridge.TAG, "$operation failed with result $result: $description")
         promise.reject(result.toString(), description)
     }
 }

--- a/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/PurchasePromiseListener.kt
+++ b/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/PurchasePromiseListener.kt
@@ -1,9 +1,9 @@
 package com.applicaster.iap.reactnative.utils
 
-import android.util.Log
 import com.applicaster.iap.reactnative.IAPBridge
 import com.applicaster.iap.uni.api.IBillingAPI
 import com.applicaster.iap.uni.api.Purchase
+import com.applicaster.util.APLogger
 import com.facebook.react.bridge.Promise
 
 open class PurchasePromiseListener(protected val bridge: IAPBridge,
@@ -16,13 +16,13 @@ open class PurchasePromiseListener(protected val bridge: IAPBridge,
 
     override fun onPurchaseFailed(result: IBillingAPI.IAPResult, description: String) {
         if(IBillingAPI.IAPResult.alreadyOwned == result) {
-            Log.d(IAPBridge.TAG, "Handling already owned error for $sku.")
+            APLogger.debug(IAPBridge.TAG, "Handling already owned error for $sku.")
             val purchase = bridge.purchases[sku]
             if(null != purchase) {
-                Log.d(IAPBridge.TAG, "Purchase $sku was found in already loaded.")
+                APLogger.debug(IAPBridge.TAG, "Purchase $sku was found in already loaded.")
                 promise.resolve(wrap(fix(purchase)))
             } else {
-                Log.d(IAPBridge.TAG, "Purchase $sku was not found in already loaded. Attempting to restore.")
+                APLogger.debug(IAPBridge.TAG, "Purchase $sku was not found in already loaded. Attempting to restore.")
                 bridge.restoreOwned(this)
             }
         }
@@ -35,7 +35,7 @@ open class PurchasePromiseListener(protected val bridge: IAPBridge,
         super.onPurchasesRestored(purchases)
         // amazon hack, too: in restore we will receive this sku
         purchases.find { it.productIdentifier.startsWith(sku) }?.let {
-            Log.d(IAPBridge.TAG, "Purchase $sku was successfully restored")
+            APLogger.debug(IAPBridge.TAG, "Purchase $sku was successfully restored")
             promise.resolve(wrap(fix(it)))
         }
     }

--- a/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/RestorePromiseListener.kt
+++ b/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/RestorePromiseListener.kt
@@ -3,13 +3,14 @@ package com.applicaster.iap.reactnative.utils
 import android.util.Log
 import com.applicaster.iap.reactnative.IAPBridge
 import com.applicaster.iap.uni.api.Purchase
+import com.applicaster.util.APLogger
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.WritableNativeArray
 
 class RestorePromiseListener(promise: Promise) : PromiseListener(promise) {
 
     override fun onPurchasesRestored(purchases: List<Purchase>) {
-        Log.d(IAPBridge.TAG, "${purchases.size} purchases were restored.")
+        APLogger.debug(IAPBridge.TAG, "${purchases.size} purchases were restored.")
         val purchasesArray = WritableNativeArray()
         purchases.forEach { purchasesArray.pushMap(wrap(it)) }
         promise.resolve(purchasesArray)

--- a/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/SKUPromiseListener.kt
+++ b/plugins/applicaster-iap-framework/android/iap-rn/src/main/java/com/applicaster/iap/reactnative/utils/SKUPromiseListener.kt
@@ -3,6 +3,7 @@ package com.applicaster.iap.reactnative.utils
 import android.util.Log
 import com.applicaster.iap.reactnative.IAPBridge
 import com.applicaster.iap.uni.api.Sku
+import com.applicaster.util.APLogger
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
@@ -12,7 +13,7 @@ class SKUPromiseListener(promise: Promise,
     : PromiseListener(promise) {
 
     override fun onSkuDetailsLoaded(skuDetails: List<Sku>) {
-        Log.d(IAPBridge.TAG, "${skuDetails.size} SKU details were loaded.")
+        APLogger.debug(IAPBridge.TAG, "${skuDetails.size} SKU details were loaded.")
         val products = WritableNativeArray()
         skuDetails.forEach {
             products.pushMap(wrap(it))

--- a/plugins/applicaster-iap-framework/android/iap-uni/build.gradle
+++ b/plugins/applicaster-iap-framework/android/iap-uni/build.gradle
@@ -30,6 +30,16 @@ android {
 }
 
 dependencies {
+
+    // Applicaster SDK
+    if (!findProject(':applicaster-android-sdk') || project.hasProperty('forceClosedDependencies')) {
+        def sdkVersion = safeExtGet('applicaster_android_sdk_core_version', '6.3.0')
+        api ("com.applicaster:applicaster-android-sdk-core:${sdkVersion}")
+    }
+    else {
+        api project(':applicaster-android-sdk')
+    }
+
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/plugins/applicaster-iap-framework/android/iap-uni/build.gradle
+++ b/plugins/applicaster-iap-framework/android/iap-uni/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
+import org.gradle.util.VersionNumber
+
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
@@ -27,6 +29,14 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+}
+
+def safeExtGet(prop, fallback) {
+    def ver = rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    if (VersionNumber.parse(fallback) > VersionNumber.parse(ver)) {
+        throw new Exception("Version mismatch for $prop: $ver found, at least $fallback required")
+    }
+    return ver
 }
 
 dependencies {

--- a/plugins/applicaster-iap-framework/android/iap-uni/consumer-rules.pro
+++ b/plugins/applicaster-iap-framework/android/iap-uni/consumer-rules.pro
@@ -1,0 +1,3 @@
+-dontwarn com.amazon.**
+-keep class com.amazon.** {*;}
+-keepattributes *Annotation*

--- a/plugins/applicaster-iap-framework/android/iap-uni/proguard-rules.pro
+++ b/plugins/applicaster-iap-framework/android/iap-uni/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-dontwarn com.amazon.**
+-keep class com.amazon.** {*;}
+-keepattributes *Annotation*

--- a/plugins/applicaster-iap-framework/android/iap-uni/src/main/java/com/applicaster/iap/uni/amazon/AmazonBillingImpl.kt
+++ b/plugins/applicaster-iap-framework/android/iap-uni/src/main/java/com/applicaster/iap/uni/amazon/AmazonBillingImpl.kt
@@ -7,6 +7,7 @@ import com.amazon.device.iap.PurchasingListener
 import com.amazon.device.iap.PurchasingService
 import com.amazon.device.iap.model.*
 import com.applicaster.iap.uni.api.*
+import com.applicaster.util.APLogger
 
 class AmazonBillingImpl : IBillingAPI, PurchasingListener {
 
@@ -43,6 +44,7 @@ class AmazonBillingImpl : IBillingAPI, PurchasingListener {
         }
 
         fun onUserDataLoaded() {
+            APLogger.debug(TAG, "User data received")
             restoreObserver = initializationListener
             PurchasingService.getPurchaseUpdates(receipts.hasPurchases())
         }
@@ -130,7 +132,7 @@ class AmazonBillingImpl : IBillingAPI, PurchasingListener {
 
         val request = skuRequests.remove(response.requestId)
         if (ProductDataResponse.RequestStatus.SUCCESSFUL != response.requestStatus) {
-            Log.e(TAG, "onSkuDetailsLoadingFailed: ${response.requestStatus}")
+            APLogger.error(TAG, "onSkuDetailsLoadingFailed: ${response.requestStatus}")
             skuRequests[response.requestId]?.onSkuDetailsLoadingFailed(
                 IBillingAPI.IAPResult.generalError,
                 response.requestStatus.toString()
@@ -148,14 +150,14 @@ class AmazonBillingImpl : IBillingAPI, PurchasingListener {
         }
         val request = purchaseRequests.remove(response.requestId)
         if (PurchaseResponse.RequestStatus.SUCCESSFUL != response.requestStatus) {
-            Log.e(TAG, "onPurchaseFailed: ${response.requestStatus}")
+            APLogger.error(TAG, "onPurchaseFailed: ${response.requestStatus}")
             if(null != request) {
                 // for items that ara not fulfilled we do not get alreadyOwned, but just error
                 // try to handle it
                 if (PurchaseResponse.RequestStatus.FAILED == response.requestStatus) {
                     val ownedPurchase = receipts.getPurchase(request.sku)
                     if (null != ownedPurchase) {
-                        Log.i(TAG, "Already owned purchase found in storage: ${request.sku}")
+                        APLogger.info(TAG, "Already owned purchase found in storage: ${request.sku}")
                         request.listener.onPurchased(ownedPurchase)
                         return
                     }
@@ -186,19 +188,21 @@ class AmazonBillingImpl : IBillingAPI, PurchasingListener {
     override fun onPurchaseUpdatesResponse(response: PurchaseUpdatesResponse?) {
         if (null != response) {
             if (response.requestStatus != PurchaseUpdatesResponse.RequestStatus.SUCCESSFUL) {
-                Log.e(TAG, "onPurchaseUpdatesResponse: ${response.requestStatus}")
+                APLogger.error(TAG, "onPurchaseUpdatesResponse: ${response.requestStatus}")
                 restoreObserver?.onPurchaseRestoreFailed(
                     IBillingAPI.IAPResult.generalError,
                     response.requestStatus.toString()
                 )
                 return
             }
+            APLogger.debug(TAG, "Got PurchaseUpdatesResponse")
             receipts.update(response.receipts, response.userData?.userId)
             if (response.hasMore()) {
                 PurchasingService.getPurchaseUpdates(false)
                 return
             }
         }
+        APLogger.debug(TAG, "PurchaseUpdatesResponse completed")
         restoreObserver?.onPurchasesRestored(receipts.getPurchases())
         restoreObserver = null
     }
@@ -209,7 +213,7 @@ class AmazonBillingImpl : IBillingAPI, PurchasingListener {
             return
         }
         if (userDataResponse.requestStatus != UserDataResponse.RequestStatus.SUCCESSFUL) {
-            Log.e(TAG, "onPurchaseUpdatesResponse: ${userDataResponse.requestStatus}")
+            APLogger.error(TAG, "onPurchaseUpdatesResponse: ${userDataResponse.requestStatus}")
             initializationListener?.onAnyError(IBillingAPI.IAPResult.generalError, "Failed to load user data")
             return
         }


### PR DESCRIPTION
Before we were relying on RN to log events, now native layer logs these as well.
