### PR TITLE
feat: additional ability to customize the user interface

### DIFF
--- a/plugins/zapp_login_plugin_oauth_2_0/manifests/localizations.config.js
+++ b/plugins/zapp_login_plugin_oauth_2_0/manifests/localizations.config.js
@@ -7,6 +7,11 @@ const common = [
     initial_value: "My Company",
   },
   {
+    key: "subtitle_text",
+    label: "Subtitle label text",
+    initial_value: "Subtitle",
+  },
+  {
     key: "login_text",
     label: "Login button text",
     initial_value: "Login",

--- a/plugins/zapp_login_plugin_oauth_2_0/manifests/manifest.config.js
+++ b/plugins/zapp_login_plugin_oauth_2_0/manifests/manifest.config.js
@@ -40,126 +40,245 @@ const baseManifest = {
 const stylesMobile = {
   fields: [
     {
-      key: "background_image",
-      type: "uploader",
-      label: "Background Image",
-      label_tooltip:
-        "Background image. It is recommended to use an image that could be centered in the different screen sizes.",
+      group: true,
+      label: "Background",
+      folded: true,
+      fields: [
+        {
+          key: "background_image",
+          type: "uploader",
+          label: "Background Image",
+          label_tooltip:
+            "Background image. It is recommended to use an image that could be centered in the different screen sizes.",
+        },
+        {
+          key: "background_color",
+          type: "color_picker",
+          label: "Background color",
+          initial_value: "#161b29ff",
+        },
+      ],
     },
     {
-      key: "background_color",
-      type: "color_picker",
-      label: "Background font color",
-      initial_value: "#161b29ff",
-    },
-    {
-      key: "client_logo",
-      type: "uploader",
+      group: true,
       label: "Logo",
-      label_tooltip: "Logo image. Dimension 200x44 pixels.",
-      placeholder: "W 200px x H 44px",
+      folded: true,
+      fields: [
+        {
+          key: "client_logo_position",
+          type: "tag_select",
+          initial_value: "middle",
+          label: "Logo position",
+          label_tooltip: "Position of the logo on the screen",
+          options: [
+            {
+              text: "Top",
+              value: "top",
+            },
+            {
+              text: "Middle",
+              value: "middle",
+            },
+          ],
+        },
+        {
+          key: "client_logo",
+          type: "uploader",
+          label: "Logo",
+          label_tooltip: "Logo image. Dimension 200x44 pixels.",
+          placeholder: "W 200px x H 44px",
+        },
+      ],
     },
     {
-      key: "title_font_ios",
-      type: "ios_font_selector",
-      label: "iOS title font",
-      initial_value: "Helvetica-Bold",
+      group: true,
+      label: "Title",
+      folded: true,
+      fields: [
+        {
+          key: "title_font_ios",
+          type: "ios_font_selector",
+          label: "iOS font family",
+          initial_value: "Helvetica-Bold",
+        },
+        {
+          key: "title_font_android",
+          type: "android_font_selector",
+          label: "Android font family",
+          initial_value: "Roboto-Bold",
+        },
+        {
+          key: "title_font_size",
+          type: "number_input",
+          label: "Font size",
+          initial_value: 15,
+        },
+        {
+          key: "title_font_color",
+          type: "color_picker",
+          label: "Color",
+          initial_value: "#ffffffff",
+        },
+      ],
     },
     {
-      key: "title_font_android",
-      type: "android_font_selector",
-      label: "Android title font",
-      initial_value: "Roboto-Bold",
+      group: true,
+      label: "Sub title",
+      folded: true,
+      fields: [
+        {
+          key: "subtitle",
+          type: "switch",
+          initial_value: false,
+          label: "Display subtitle",
+        },
+        {
+          key: "subtitle_font_ios",
+          type: "ios_font_selector",
+          label: "iOS font family",
+          initial_value: "Helvetica-Bold",
+          conditional_fields: [
+            {
+              key: "styles/subtitle",
+              condition_value: true,
+            },
+          ],
+        },
+        {
+          key: "subtitle_font_android",
+          type: "android_font_selector",
+          label: "Android font family",
+          initial_value: "Roboto-Bold",
+          conditional_fields: [
+            {
+              key: "styles/subtitle",
+              condition_value: true,
+            },
+          ],
+        },
+        {
+          key: "subtitle_font_size",
+          type: "number_input",
+          label: "Font size",
+          initial_value: 15,
+          conditional_fields: [
+            {
+              key: "styles/subtitle",
+              condition_value: true,
+            },
+          ],
+        },
+        {
+          key: "subtitle_font_color",
+          type: "color_picker",
+          label: "Color",
+          initial_value: "#ffffffff",
+          conditional_fields: [
+            {
+              key: "styles/subtitle",
+              condition_value: true,
+            },
+          ],
+        },
+      ],
     },
     {
-      key: "title_font_size",
-      type: "number_input",
-      label: "Title font size",
-      initial_value: 15,
+      group: true,
+      label: "Back button",
+      folded: true,
+      fields: [
+        {
+          key: "back_button_force_display",
+          type: "switch",
+          initial_value: false,
+          label: "Force display",
+          label_tooltip: "If true, then the button will always be displayed. If false, then only on the player's hook",
+        },
+        {
+          key: "back_button_position",
+          type: "tag_select",
+          initial_value: "top",
+          label: "Back button position",
+          label_tooltip: "Position of the back button on the screen",
+          options: [
+            {
+              text: "Top & Left",
+              value: "top",
+            },
+            {
+              text: "Bottom",
+              value: "bottom",
+            },
+          ],
+        },
+        {
+          key: "back_button_font_ios",
+          type: "ios_font_selector",
+          label: "iOS font family",
+          initial_value: "Helvetica-Bold",
+        },
+        {
+          key: "back_button_font_android",
+          type: "android_font_selector",
+          label: "Android font family",
+          initial_value: "Roboto-Bold",
+        },
+        {
+          key: "back_button_font_size",
+          type: "number_input",
+          label: "Font size",
+          initial_value: 15,
+        },
+        {
+          key: "back_button_font_color",
+          type: "color_picker",
+          label: "Color",
+          initial_value: "#ffffffff",
+        },
+      ],
     },
     {
-      key: "title_font_color",
-      type: "color_picker",
-      label: "Title font color",
-      initial_value: "#ffffffff",
-    },
-    {
-      key: "back_button_font_ios",
-      type: "ios_font_selector",
-      label: "iOS back button font",
-      initial_value: "Helvetica-Bold",
-    },
-    {
-      key: "back_button_font_android",
-      type: "android_font_selector",
-      label: "Android back button font",
-      initial_value: "Roboto-Bold",
-    },
-    {
-      key: "back_button_font_size",
-      type: "number_input",
-      label: "Back button font size",
-      initial_value: 15,
-    },
-    {
-      key: "back_button_font_color",
-      type: "color_picker",
-      label: "Back button font color",
-      initial_value: "#ffffffff",
-    },
-    {
-      key: "action_button_font_ios",
-      type: "ios_font_selector",
-      label: "iOS Action button font",
-      initial_value: "Helvetica-Bold",
-    },
-    {
-      key: "action_button_font_android",
-      type: "android_font_selector",
-      label: "Android Action button font",
-      initial_value: "Roboto-Bold",
-    },
-    {
-      key: "action_button_font_size",
-      type: "number_input",
-      label: "Action button font size",
-      initial_value: 15,
-    },
-    {
-      key: "action_button_font_color",
-      type: "color_picker",
-      label: "Action button font color",
-      initial_value: "#ffffffff",
-    },
-    {
-      key: "action_button_background_color",
-      type: "color_picker",
-      label: "Action button font color",
-      initial_value: "#F1AD12ff",
-    },
-    {
-      key: "back_button_font_ios",
-      type: "ios_font_selector",
-      label: "iOS back button font",
-      initial_value: "Roboto-Bold",
-    },
-    {
-      key: "back_button_font_android",
-      type: "android_font_selector",
-      label: "Android back button font",
-      initial_value: "Roboto-Bold",
-    },
-    {
-      key: "back_button_font_size",
-      type: "number_input",
-      label: "Back button font size",
-      initial_value: 15,
-    },
-    {
-      key: "back_button_font_color",
-      type: "color_picker",
-      label: "Back button font color",
-      initial_value: "#ffffffff",
+      group: true,
+      label: "Action button",
+      folded: true,
+      fields: [
+        {
+          key: "action_button_font_ios",
+          type: "ios_font_selector",
+          label: "iOS font family",
+          initial_value: "Helvetica-Bold",
+        },
+        {
+          key: "action_button_font_android",
+          type: "android_font_selector",
+          label: "Android font family",
+          initial_value: "Roboto-Bold",
+        },
+        {
+          key: "action_button_font_size",
+          type: "number_input",
+          label: "Font size",
+          initial_value: 15,
+        },
+        {
+          key: "action_button_font_color",
+          type: "color_picker",
+          label: "Color",
+          initial_value: "#ffffffff",
+        },
+        {
+          key: "action_button_background_color",
+          type: "color_picker",
+          label: "Background color",
+          initial_value: "#F1AD12ff",
+        },
+        {
+          key: "action_button_border_radius",
+          type: "number_input",
+          label: "Border radius",
+          initial_value: 10,
+        },
+      ],
     },
   ],
 };
@@ -578,4 +697,5 @@ function createManifest({ version, platform }) {
     targets: isTV ? ["tv"] : ["mobile"],
   };
 }
+
 module.exports = createManifest;

--- a/plugins/zapp_login_plugin_oauth_2_0/src/Components/OAuth.js
+++ b/plugins/zapp_login_plugin_oauth_2_0/src/Components/OAuth.js
@@ -70,6 +70,7 @@ const OAuth = (props) => {
     logout_text,
     login_text,
     title_text,
+    subtitle_text,
     back_button_text,
   } = screenLocalizations;
 
@@ -262,12 +263,12 @@ const OAuth = (props) => {
           <View style={containerStyle}>
             <BackButton
               title={back_button_text}
-              disabled={hookType !== HookTypeData.PLAYER_HOOK}
+              disabled={!(hookType === HookTypeData.PLAYER_HOOK || screenStyles?.back_button_force_display)}
               screenStyles={screenStyles}
               onPress={onBackButton}
             />
-            <TitleLabel screenStyles={screenStyles} title={title_text} />
-            <View style={clientLogoView}>
+            <TitleLabel screenStyles={screenStyles} title={title_text} subtitle={subtitle_text} />
+            <View style={[clientLogoView.default, clientLogoView[screenStyles?.client_logo_position]]}>
               <ClientLogo imageSrc={screenStyles.client_logo} />
             </View>
             <ActionButton

--- a/plugins/zapp_login_plugin_oauth_2_0/src/Components/Styles/index.js
+++ b/plugins/zapp_login_plugin_oauth_2_0/src/Components/Styles/index.js
@@ -25,9 +25,17 @@ export function backgroundImageStyle(screenStyles, hookType, width, height) {
 }
 
 export const clientLogoView = {
-  height: 100,
-  width: 350,
-  position: "absolute",
-  alignSelf: "center",
-  top: 200,
+  default: {
+    height: 100,
+    width: 350,
+    position: "absolute",
+    alignSelf: "center",
+    top: 200,
+  },
+  top: {
+    top: 70,
+  },
+  middle: {
+    rop: 230,
+  }
 };

--- a/plugins/zapp_login_plugin_oauth_2_0/src/Components/UIComponents/Buttons/ActionButton.js
+++ b/plugins/zapp_login_plugin_oauth_2_0/src/Components/UIComponents/Buttons/ActionButton.js
@@ -11,7 +11,7 @@ const actionButtonContainerStyle = (screenStyles, customStyle) => {
     alignItems: "center",
     justifyContent: "center",
     backgroundColor: screenStyles?.action_button_background_color || "#F1AD12",
-    borderRadius: 10,
+    borderRadius: screenStyles?.action_button_border_radius,
     alignSelf: "center",
   };
 

--- a/plugins/zapp_login_plugin_oauth_2_0/src/Components/UIComponents/Buttons/BackButton.js
+++ b/plugins/zapp_login_plugin_oauth_2_0/src/Components/UIComponents/Buttons/BackButton.js
@@ -1,32 +1,44 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Text, TouchableOpacity } from "react-native";
+import { Text, TouchableOpacity, StyleSheet } from "react-native";
 import { platformSelect } from "@applicaster/zapp-react-native-utils/reactUtils";
 
 const BackButton = ({ onPress, disabled, screenStyles, title }) => {
-  const containerStyle = {
+  const styles = getStyles(screenStyles);
+
+  return disabled === true ? null : (
+    <TouchableOpacity
+      style={[styles.defaultContainer, screenStyles?.back_button_position === "bottom" && styles.bottomContainer]}
+      onPress={onPress}
+    >
+      <Text style={styles.text}>{title}</Text>
+    </TouchableOpacity>
+  );
+};
+
+const getStyles = (screenStyles) => StyleSheet.create({
+  defaultContainer: {
     alignSelf: "flex-start",
     marginLeft: 35,
     marginTop: 20,
     zIndex: 100,
     position: "absolute",
-  };
-
-  const TextStyle = {
+  },
+  bottomContainer: {
+    alignSelf: "center",
+    marginLeft: 0,
+    marginTop: 10,
+    bottom: 65
+  },
+  text: {
     fontFamily: platformSelect({
       ios: screenStyles?.back_button_font_ios,
       android: screenStyles?.back_button_font_android,
     }),
     fontSize: screenStyles?.back_button_font_size,
     color: screenStyles?.back_button_font_color,
-  };
-
-  return disabled === true ? null : (
-    <TouchableOpacity style={containerStyle} onPress={onPress}>
-      <Text style={TextStyle}>{title}</Text>
-    </TouchableOpacity>
-  );
-};
+  }
+});
 
 BackButton.propTypes = {
   title: PropTypes.string,

--- a/plugins/zapp_login_plugin_oauth_2_0/src/Components/UIComponents/TitleLabel/index.js
+++ b/plugins/zapp_login_plugin_oauth_2_0/src/Components/UIComponents/TitleLabel/index.js
@@ -1,24 +1,46 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Text } from "react-native";
+import { Text, StyleSheet, View } from "react-native";
 import { platformSelect } from "@applicaster/zapp-react-native-utils/reactUtils";
 
-const TitleLabel = ({ screenStyles, title }) => {
-  const style = {
+const TitleLabel = ({ screenStyles, title, subtitle }) => {
+  const styles = getStyles(screenStyles);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{title}</Text>
+      {screenStyles?.subtitle && <Text style={styles.subtitle}>{subtitle}</Text>}
+    </View>
+  );
+};
+
+const getStyles = (screenStyles) => StyleSheet.create({
+  container: {
+    marginHorizontal: 40,
+    marginTop: screenStyles?.client_logo_position === "top" ? 220 : 100,
+    marginBottom: 80,
+    alignSelf: "center",
+  },
+  title: {
+    textAlign: "center",
+    fontSize: screenStyles?.title_font_size,
+    color: screenStyles?.title_font_color,
     fontFamily: platformSelect({
       ios: screenStyles?.title_font_ios,
       android: screenStyles?.title_font_android,
     }),
-    fontSize: screenStyles?.title_font_size,
-    color: screenStyles?.title_font_color,
-    marginTop: 100,
-    marginBottom: 80,
-    alignSelf: "center",
+  },
+  subtitle: {
+    marginTop: 20,
     textAlign: "center",
-  };
-
-  return <Text style={style}>{title}</Text>;
-};
+    fontSize: screenStyles?.subtitle_font_size,
+    color: screenStyles?.subtitle_font_color,
+    fontFamily: platformSelect({
+      ios: screenStyles?.subtitle_font_ios,
+      android: screenStyles?.subtitle_font_android,
+    }),
+  }
+});
 
 TitleLabel.propTypes = {
   title: PropTypes.string,


### PR DESCRIPTION
## Description:

This PR provides more options for customizing the plugin's user interface:

1. Change the position of the logo in the UI builder (Top/Middle)
2. Add/change subtitle and text styles of the subtitle
3. Change the position of the back button in the UI builder (Top&Left/Bottom)
4. Change the border-radius of the action button
5. (optional) Always display the back button (not only for player prehook)

Backward compatible with the previous version of the manifest

Previous UI (Full customization):
![Screenshot 2021-03-16 at 17 30 25](https://user-images.githubusercontent.com/30141829/111336196-0f938d80-8686-11eb-8427-5022b5d97945.png)

New UI (Full customization):
![Screenshot 2021-03-16 at 17 31 37](https://user-images.githubusercontent.com/30141829/111336245-1c17e600-8686-11eb-8656-5d7094dd36b8.png)

