### PR TITLE
fix: added "allow_screen_plugin_presentation" flag to the manifest

### DIFF
--- a/plugins/zapp_login_plugin_oauth_2_0/manifests/manifest.config.js
+++ b/plugins/zapp_login_plugin_oauth_2_0/manifests/manifest.config.js
@@ -17,7 +17,17 @@ const baseManifest = {
   deprecated_since_zapp_sdk: "",
   unsupported_since_zapp_sdk: "",
   preload: true,
-
+  general: {
+    fields: [
+      {
+        type: "switch",
+        label: "Show full screen",
+        tooltip: "Enabling this setting will hide both the nav bar and the menu on the screen",
+        key: "allow_screen_plugin_presentation",
+        initial_value: true,
+      }
+    ]
+  },
   hooks: {
     fields: [
       {


### PR DESCRIPTION
## Description:
In **zapp_login_plugin_oauth_2_0** added the ability to configure the display of the navbar if the plugin does not open as a pre-hook
