### PR TITLE
fix: move DI data to SessionStorage

### DIFF
--- a/localProject/apple/FrameworksApp.xcodeproj/project.pbxproj
+++ b/localProject/apple/FrameworksApp.xcodeproj/project.pbxproj
@@ -28,9 +28,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		041F6A387BE8477DFC50073C /* Pods-FrameworksApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FrameworksApp.release.xcconfig"; path = "../../plugins/zapp_local_notifications/Files/apple/Pods/Target Support Files/Pods-FrameworksApp/Pods-FrameworksApp.release.xcconfig"; sourceTree = "<group>"; };
+		041F6A387BE8477DFC50073C /* Pods-FrameworksApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FrameworksApp.release.xcconfig"; path = "../../../plugins/applicaster-di-manager/apple/Pods/Target Support Files/Pods-FrameworksApp/Pods-FrameworksApp.release.xcconfig"; sourceTree = "<group>"; };
 		1EE912D39F001556FF471E7C /* Pods_FrameworksApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FrameworksApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2784FE0014A122DAF6C9ADF8 /* Pods-FrameworksApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FrameworksApp.debug.xcconfig"; path = "../../plugins/zapp_local_notifications/Files/apple/Pods/Target Support Files/Pods-FrameworksApp/Pods-FrameworksApp.debug.xcconfig"; sourceTree = "<group>"; };
+		2784FE0014A122DAF6C9ADF8 /* Pods-FrameworksApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FrameworksApp.debug.xcconfig"; path = "../../../plugins/applicaster-di-manager/apple/Pods/Target Support Files/Pods-FrameworksApp/Pods-FrameworksApp.debug.xcconfig"; sourceTree = "<group>"; };
 		402FF58B23BA3B6600469430 /* FrameworksApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FrameworksApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		402FF58E23BA3B6600469430 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		402FF59223BA3B6600469430 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -42,8 +42,8 @@
 		402FF5A523BA3B6800469430 /* FrameworksAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworksAppTests.swift; sourceTree = "<group>"; };
 		402FF5A723BA3B6800469430 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		953B39070E8820E8215B9E77 /* Pods_FrameworksAppTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FrameworksAppTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		989FD4B75C509B5299545AD6 /* Pods-FrameworksAppTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FrameworksAppTests.release.xcconfig"; path = "../../plugins/zapp_local_notifications/Files/apple/Pods/Target Support Files/Pods-FrameworksAppTests/Pods-FrameworksAppTests.release.xcconfig"; sourceTree = "<group>"; };
-		E37ADDED5CFB8C30921464BA /* Pods-FrameworksAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FrameworksAppTests.debug.xcconfig"; path = "../../plugins/zapp_local_notifications/Files/apple/Pods/Target Support Files/Pods-FrameworksAppTests/Pods-FrameworksAppTests.debug.xcconfig"; sourceTree = "<group>"; };
+		989FD4B75C509B5299545AD6 /* Pods-FrameworksAppTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FrameworksAppTests.release.xcconfig"; path = "../../../plugins/applicaster-di-manager/apple/Pods/Target Support Files/Pods-FrameworksAppTests/Pods-FrameworksAppTests.release.xcconfig"; sourceTree = "<group>"; };
+		E37ADDED5CFB8C30921464BA /* Pods-FrameworksAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FrameworksAppTests.debug.xcconfig"; path = "../../../plugins/applicaster-di-manager/apple/Pods/Target Support Files/Pods-FrameworksAppTests/Pods-FrameworksAppTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -460,7 +460,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = FrameworksApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -479,7 +479,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = FrameworksApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/plugins/applicaster-di-manager/android/src/main/java/com/applicaster/plugin/dimanager/DIManager.kt
+++ b/plugins/applicaster-di-manager/android/src/main/java/com/applicaster/plugin/dimanager/DIManager.kt
@@ -6,7 +6,7 @@ import com.applicaster.plugin_manager.Plugin
 import com.applicaster.plugin_manager.delayedplugin.DelayedPlugin
 import com.applicaster.plugin_manager.hook.ApplicationLoaderHookUpI
 import com.applicaster.plugin_manager.hook.HookListener
-import com.applicaster.storage.LocalStorage
+import com.applicaster.session.SessionStorage
 import com.applicaster.util.APLogger
 import com.applicaster.util.AppContext
 import com.applicaster.util.OSUtil
@@ -73,7 +73,7 @@ class DIManager : GenericPluginI, ApplicationLoaderHookUpI, DelayedPlugin {
                 if (token.isNullOrBlank()) {
                     APLogger.error(TAG, "DIManager plugin received empty token")
                 } else {
-                    LocalStorage.set(jwtStorageKey, token)
+                    SessionStorage.set(jwtStorageKey, token)
                 }
             } catch (e: Exception) {
                 APLogger.error(TAG, "DIManager plugin failed to fetch $serverUrl", e)
@@ -98,7 +98,7 @@ class DIManager : GenericPluginI, ApplicationLoaderHookUpI, DelayedPlugin {
     }
 
     override fun disable(): Boolean {
-        LocalStorage.remove(jwtStorageKey)
+        SessionStorage.remove(jwtStorageKey)
         return true
     }
 }

--- a/plugins/applicaster-di-manager/apple/Podfile
+++ b/plugins/applicaster-di-manager/apple/Podfile
@@ -1,6 +1,6 @@
 source 'https://cdn.cocoapods.org/'
 
-platform :ios, '11.0'
+platform :ios, '12.0'
 install! 'cocoapods', :share_schemes_for_development_pods => true
 project '../../../localProject/apple/FrameworksApp.xcodeproj'
 
@@ -11,9 +11,12 @@ end
 
 target 'FrameworksApp' do
   use_frameworks!
-  pod 'ZappSessionStorageIdfa', :path => './ZappSessionStorageIdfa.podspec', :testspecs => ['UnitTests']
+  pod 'ZappDiManager', :path => './ZappDiManager.podspec', :testspecs => ['UnitTests']
   pod 'ZappCore', path: '../../zapp-core/apple/ZappCore.podspec'
-
+  pod 'QuickBrickXray', path: '../../quick-brick-xray/apple/QuickBrickXray.podspec'
+  pod 'XrayLogger', path: '../../../node_modules/@applicaster/x-ray/apple/Xraylogger.podspec'
+  pod 'Reporter', path: '../../../node_modules/@applicaster/x-ray/apple/Reporter.podspec'
+  pod 'LoggerInfo', path: '../../../node_modules/@applicaster/x-ray/apple/LoggerInfo.podspec'
   target 'FrameworksAppTests' do
     inherit! :search_paths
   end

--- a/plugins/applicaster-di-manager/apple/tests/Dummy.swift
+++ b/plugins/applicaster-di-manager/apple/tests/Dummy.swift
@@ -1,0 +1,31 @@
+//
+//  Dummy.swift
+//  MyTest
+//
+//  Created by Anton Kononenko on 1/9/20.
+//  Copyright © 2020 Applicaster. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+class Dummy:XCTestCase {
+    
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+}

--- a/plugins/applicaster-di-manager/package.json
+++ b/plugins/applicaster-di-manager/package.json
@@ -16,6 +16,9 @@
   "bugs": {
     "url": "https://github.com/applicaster/Zapp-Frameworks"
   },
+  "dependencies": {
+    "@applicaster/x-ray": "0.2.0"
+  },
   "homepage": "https://github.com/applicaster/Zapp-Frameworks",
   "applicaster": {
     "supportedPlatforms": [


### PR DESCRIPTION
On iOS token was recently move from LocalStorage to SessionStorage, but Android was not updated.
It actually rises a lot of questions on what we will do in the offline mode, when user will go back online (some random parts of the app won't work for no visible reasons). We can't make token request on demand since we use storage to communicate (only if we will wrap it on RN and introduce bridge or do something like OnDeviceOnline handlers)