### PR TITLE
feat: add theo ads events

### DIFF
--- a/plugins/zapp-react-native-theo-player/android/build.gradle
+++ b/plugins/zapp-react-native-theo-player/android/build.gradle
@@ -65,6 +65,7 @@ dependencies {
 
     //implementation fileTree(dir: "./src/main/libs/", include: ["*.jar", "*.aar"])
     implementation files("./src/main/libs/theoplayer-android-dist-56fffd95-3465-4f64-9eaa-9130e9c4b135-2.82.0-minapi21-release.aar")
+    implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.22.0'
     implementation "com.facebook.react:react-native:+"
     implementation "androidx.annotation:annotation:1.1.0"
     implementation "androidx.core:core-ktx:+"

--- a/plugins/zapp-react-native-theo-player/android/src/main/java/com/theoplayerreactnative/events/AdEventMapper.kt
+++ b/plugins/zapp-react-native-theo-player/android/src/main/java/com/theoplayerreactnative/events/AdEventMapper.kt
@@ -56,7 +56,10 @@ object AdEventMapper {
         (ad as? NonLinearAd?)?.let {
             map.putString("resourceURI", it.resourceURI)
         }
-        ad.adBreak?.let { map.putInt("breakSize", it.ads.size) }
+        ad.adBreak?.let {
+            map.putInt("breakSize", it.ads.size)
+            map.putInt("adPosition", it.ads.indexOf(ad))
+        }
     }
 
 }

--- a/plugins/zapp-react-native-theo-player/android/src/main/java/com/theoplayerreactnative/events/AdEventMapper.kt
+++ b/plugins/zapp-react-native-theo-player/android/src/main/java/com/theoplayerreactnative/events/AdEventMapper.kt
@@ -22,6 +22,7 @@ object AdEventMapper {
         map.putInt("maxDuration", adBreak.maxDuration)
         map.putDouble("maxRemainingDuration", adBreak.maxRemainingDuration)
         map.putString("integrationKind", adBreak.integration.type)
+        map.putInt("breakSize", adBreak.ads.size)
     }
 
     @JvmStatic
@@ -55,6 +56,7 @@ object AdEventMapper {
         (ad as? NonLinearAd?)?.let {
             map.putString("resourceURI", it.resourceURI)
         }
+        ad.adBreak?.let { map.putInt("breakSize", it.ads.size) }
     }
 
 }

--- a/plugins/zapp-react-native-theo-player/package.json
+++ b/plugins/zapp-react-native-theo-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/zapp-react-native-theo-player",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "author": "Zapp Team",
   "license": "ISC",
   "description": "THEOplayer with React Native wrapper",


### PR DESCRIPTION
Ads events added:

## Ad breaks
- onAdBreakBegin
  -  timeOffset: int
  - maxDuration: int
  - maxRemainingDuration: int
  - integrationKind: string
  - breakSize: int (how many ads inside)
- onAdBreakEnd
  - same as above

## Ads
- onAdBegin (id: String?)
  - id: String?
  - type: string?
  - duration: Int? (for LinearAd)
  - creativeId: String? (for Google IMA)
  - adSystem: String? (for Google IMA)
  - resourceURI: String? (for NonLinearAd)
  - breakSize: int (how many ads parent ad block has)
  - adPosition: int
- onAdEnd (id: String?)
  - same as above
- onAdError
  - same as above
  - error: string

More data can be added if needed:
https://docs.theoplayer.com/api-reference/android/index.html

Need to add these events to QB docs, analytics and analytics documentation.
 - https://docs.google.com/spreadsheets/d/1Rff5f1-Bbdrf_lTv-u-j_Iws-nWU-DMWx3Q0v3idM8c/edit#gid=1309822506
 - https://docs.google.com/spreadsheets/d/1uKyr5fRyCf5ek_S6Bt7U1-cOBm5GxNitWVOAuphJRw8/edit#gid=0