### PR TITLE
fix: allow null throwable since interface java allows it

### DIFF
--- a/plugins/quick-brick-xray/android/src/main/java/com/applicaster/plugin/xray/logadapters/APLoggerAdapter.kt
+++ b/plugins/quick-brick-xray/android/src/main/java/com/applicaster/plugin/xray/logadapters/APLoggerAdapter.kt
@@ -17,6 +17,8 @@ class APLoggerAdapter : IAPLogger {
 
     override fun error(tag: String, msg: String) = logger.e(tag).message(msg)
 
-    override fun error(tag: String, msg: String, t: Throwable) =
-            logger.e(tag).exception(t).message(msg)
+    override fun error(tag: String, msg: String, t: Throwable?) = when (t) {
+        null -> error(tag, msg)
+        else -> logger.e(tag).exception(t).message(msg)
+    }
 }


### PR DESCRIPTION
IAPLogger allows to pass null as Throwable, while xray IEventBuilder does not, so we must handle it in wrapper.