### PR TITLE
feat: didomi logo

### DIFF
--- a/plugins/applicaster-cmp-didomi/android/src/main/java/com/applicaster/plugin/didomi/DidomiPlugin.kt
+++ b/plugins/applicaster-cmp-didomi/android/src/main/java/com/applicaster/plugin/didomi/DidomiPlugin.kt
@@ -74,7 +74,7 @@ class DidomiPlugin : GenericPluginI
                 )
                 addEventListener(this@DidomiPlugin)
                 onReady {
-                    hackLogo()
+                    validateLogo()
                     APLogger.info(TAG, "Didomi initialized")
                     if (!shouldConsentBeCollected()) {
                         APLogger.info(TAG, "User consent was already requested or not needed")
@@ -173,33 +173,16 @@ class DidomiPlugin : GenericPluginI
         }
     }
 
-    private fun hackLogo() {
+    private fun validateLogo() {
         val plugin = PluginManager.getInstance().getPlugin(PluginId)
         val bundleValue = plugin.getConfiguration()?.get(pluginAssetsKey) ?: return
-
         if (!bundleValue.isJsonPrimitive
                 || !bundleValue.asJsonPrimitive.isString
                 || bundleValue.asJsonPrimitive.asString.isEmpty()) {
             return
         }
-
-        // hack to force embedded logo image while still using remote configuration
-        AppContext.get().apply {
-            try {
-                val identifier = resources.getIdentifier(logoDrawableName, "drawable", packageName)
-                if (0 == identifier) {
-                    APLogger.info(TAG, "hackLogo failed, asset bundle zip is present, but logo image file named $logoDrawableName is missing")
-                    return
-                }
-                val logoField = Didomi::class.java.getDeclaredField("l")
-                logoField.isAccessible = true
-                logoField.setInt(Didomi.getInstance(), identifier)
-            } catch (e: NoSuchFieldException) {
-                APLogger.error(TAG, "hackLogo failed, logo resource ID field is missing in the class")
-            } catch (e: Exception) {
-                APLogger.error(TAG, "Failed to set logo image", e)
-            }
-        }
+        if (0 != Didomi.getInstance().logoResourceId) return
+        APLogger.error(TAG, "Logo asset bundle zip is present, but logo image file did not match provided one provided in the console")
     }
 
     companion object {
@@ -210,7 +193,6 @@ class DidomiPlugin : GenericPluginI
         const val didomiGDPRApplies = "IABTCF_gdprApplies"
         const val didomiIABConsent = "IABTCF_TCString"
 
-        private const val logoDrawableName = "didomi_logo"
         private const val pluginAssetsKey = "android_assets_bundle"
     }
 }

--- a/plugins/applicaster-cmp-didomi/manifests/manifest.config.js
+++ b/plugins/applicaster-cmp-didomi/manifests/manifest.config.js
@@ -118,7 +118,7 @@ const custom_configuration_fields_android = custom_configuration_fields_apple.co
       "key": "android_assets_bundle",
       "type": "uploader",
       "label": "Logo drawables zip",
-      "label_tooltip": "Please upload a zip file to provide the logo assets for this plugin. File name must be didomi_logo.png"
+      "label_tooltip": "Please upload a zip file to provide the logo assets for this plugin. File name must match json override in the Didomi web console"
     }]);
 
 const custom_configuration_fields = {

--- a/plugins/applicaster-cmp-didomi/manifests/manifest.config.js
+++ b/plugins/applicaster-cmp-didomi/manifests/manifest.config.js
@@ -95,7 +95,7 @@ function createManifest({ version, platform }) {
   return manifest;
 }
 
-const custom_configuration_fields = [
+const custom_configuration_fields_shared = [
   {
     key: "present_on_startup",
     type: "checkbox",
@@ -113,7 +113,7 @@ const custom_configuration_fields = [
   }
 ];
 
-const custom_configuration_fields_apple = custom_configuration_fields.concat(
+const custom_configuration_fields_apple = custom_configuration_fields_shared.concat(
   [{
     key: "ios_assets_bundle",
     type: "uploader",
@@ -121,7 +121,7 @@ const custom_configuration_fields_apple = custom_configuration_fields.concat(
     label_tooltip: "Please upload a zip file to provide the logo assets for this plugin. File name must match json override in the Didomi web console"
   }]);
 
-const custom_configuration_fields_android = custom_configuration_fields.concat(
+const custom_configuration_fields_android = custom_configuration_fields_shared.concat(
     [{
       "key": "android_assets_bundle",
       "type": "uploader",

--- a/plugins/applicaster-cmp-didomi/manifests/manifest.config.js
+++ b/plugins/applicaster-cmp-didomi/manifests/manifest.config.js
@@ -111,6 +111,12 @@ const custom_configuration_fields_apple = [
     default: "",
     tooltip_text: "API key",
   },
+  {
+    key: "ios_assets_bundle",
+    type: "uploader",
+    label: "Logo drawables zip",
+    label_tooltip: "Please upload a zip file to provide the logo assets for this plugin. File name must match json override in the Didomi web console"
+  }
 ];
 
 const custom_configuration_fields_android = custom_configuration_fields_apple.concat(

--- a/plugins/applicaster-cmp-didomi/manifests/manifest.config.js
+++ b/plugins/applicaster-cmp-didomi/manifests/manifest.config.js
@@ -95,7 +95,7 @@ function createManifest({ version, platform }) {
   return manifest;
 }
 
-const custom_configuration_fields_apple = [
+const custom_configuration_fields = [
   {
     key: "present_on_startup",
     type: "checkbox",
@@ -110,16 +110,18 @@ const custom_configuration_fields_apple = [
     label: "API key",
     default: "",
     tooltip_text: "API key",
-  },
-  {
+  }
+];
+
+const custom_configuration_fields_apple = custom_configuration_fields.concat(
+  [{
     key: "ios_assets_bundle",
     type: "uploader",
     label: "Logo drawables zip",
     label_tooltip: "Please upload a zip file to provide the logo assets for this plugin. File name must match json override in the Didomi web console"
-  }
-];
+  }]);
 
-const custom_configuration_fields_android = custom_configuration_fields_apple.concat(
+const custom_configuration_fields_android = custom_configuration_fields.concat(
     [{
       "key": "android_assets_bundle",
       "type": "uploader",

--- a/plugins/applicaster-cmp-didomi/manifests/manifest.config.js
+++ b/plugins/applicaster-cmp-didomi/manifests/manifest.config.js
@@ -113,7 +113,13 @@ const custom_configuration_fields_apple = [
   },
 ];
 
-const custom_configuration_fields_android = custom_configuration_fields_apple;
+const custom_configuration_fields_android = custom_configuration_fields_apple.concat(
+    [{
+      "key": "android_assets_bundle",
+      "type": "uploader",
+      "label": "Logo drawables zip",
+      "label_tooltip": "Please upload a zip file to provide the logo assets for this plugin. File name must be didomi_logo.png"
+    }]);
 
 const custom_configuration_fields = {
   ios_for_quickbrick: custom_configuration_fields_apple,


### PR DESCRIPTION
Didomi does not support remote URL logos on mobile (they actually fetch it, but have incomplete implementation for displaying).
And web console does not allows to input drawable resource name (it requires URL), but it can be overridden manually in Didomi console.
We add an upload option and validation code for that flow

<img width="384" alt="Screen Shot 2021-04-30 at 17 29 53" src="https://user-images.githubusercontent.com/24409942/116756184-b08d9c00-a9d9-11eb-9e49-4bf4bb22345f.png">
