### PR TITLE
fix: better didomi setup validation

### DIFF
--- a/plugins/applicaster-cmp-didomi/android/src/main/java/com/applicaster/plugin/didomi/DidomiPlugin.kt
+++ b/plugins/applicaster-cmp-didomi/android/src/main/java/com/applicaster/plugin/didomi/DidomiPlugin.kt
@@ -74,7 +74,6 @@ class DidomiPlugin : GenericPluginI
                 )
                 addEventListener(this@DidomiPlugin)
                 onReady {
-                    validateLogo()
                     APLogger.info(TAG, "Didomi initialized")
                     if (!shouldConsentBeCollected()) {
                         APLogger.info(TAG, "User consent was already requested or not needed")
@@ -90,6 +89,10 @@ class DidomiPlugin : GenericPluginI
                                 super.hideNotice(event)
                                 removeEventListener(this)
                                 storeConsent()
+                                // Do the logo validation check after the notice was presented,
+                                // since sometimes it's not yet initialized before that,
+                                // and it's still ok to inform the user a bit later.
+                                validateLogo()
                                 listener.onHookFinished()
                             }
                         })


### PR DESCRIPTION
I have an integrity check for logo, but there is a race condition, onReady can arrive before Didomi updates the logo resource. User does not really care about the sequence, and showNotice is not called from RN, only on the start, so I can just move the check to the point after notice was presented