### PR TITLE
feat: localized default topics

### DIFF
--- a/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/services/APMessagingService.kt
+++ b/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/services/APMessagingService.kt
@@ -131,7 +131,10 @@ class APMessagingService : FirebaseMessagingService() {
         // run on UI thread, since some devices can't publish notifications from background threads
         GlobalScope.launch(Dispatchers.Main) {
             with(NotificationManagerCompat.from(this@APMessagingService.applicationContext)) {
-                notify(notificationFactory.generateNotificationId(), notification)
+                if(pushMessage.tag.isEmpty())
+                    notify(notificationFactory.generateNotificationId(), notification)
+                else
+                    notify(pushMessage.tag, notificationFactory.generateNotificationId(), notification)
             }
         }
     }

--- a/plugins/zapp-push-plugin-firebase/manifests/manifest.config.js
+++ b/plugins/zapp-push-plugin-firebase/manifests/manifest.config.js
@@ -103,6 +103,13 @@ const custom_configuration_fields_android = [
     tooltip_text: "Topics to subscribe to, separated with comma"
   },
   {
+    key: "default_localized_topics",
+    type: "text",
+    label: "Default Localized topics",
+    default: "general",
+    tooltip_text: "Topics to subscribe to, separated with comma that will have appended language (ex. general-en)"
+  },
+  {
     key: "notification_channel_name",
     type: "text",
     tooltip_text: "Name of the default notification channel",
@@ -292,7 +299,7 @@ const custom_configuration_fields = {
 };
 
 const min_zapp_sdk = {
-  android_for_quickbrick: "2.0.1-dev",
+  android_for_quickbrick: "4.0.0",
   ios_for_quickbrick: "3.0.0-Dev",
 };
 


### PR DESCRIPTION
Support for localized default topics added.
Also we now keep track of topics that we 'own', i.e. register by default. If something got changed due to locale change or configuration update in Zapp, change will be propagated: removed topics will be unsubscribed from, and new one will be subscribed to.