### PR TITLE
feat: pass url to native

### DIFF
--- a/plugins/quick-brick-opta-stats/src/index.js
+++ b/plugins/quick-brick-opta-stats/src/index.js
@@ -51,7 +51,9 @@ export default NativeScreen = ({ screenData }: Props) => {
   const screenPackage = NativeModules?.[packageName];
   const method = screenPackage?.[methodName];
 
-  if(!screenData['url']) {
+  const { url } = screenData
+
+  if(!url) {
     // show home screen (url is always null for now)
     return <OptaStatsContainer style={styles.container}></OptaStatsContainer>
   }
@@ -104,7 +106,7 @@ export default NativeScreen = ({ screenData }: Props) => {
       // todo: add params
 
       try {
-        const res = await method({});
+        const res = await method({url});
         logger.info(`Received response from native method ${methodName}`, res);
         onDismiss();
       } catch (error) {

--- a/plugins/quick-brick-opta-stats/src/index.js
+++ b/plugins/quick-brick-opta-stats/src/index.js
@@ -10,6 +10,8 @@ import { styles, stylesError } from "./styles";
 
 import {requireNativeComponent} from 'react-native';
 
+import { schemeHandlerHooks } from "@applicaster/quick-brick-core/App/DeepLinking/URLSchemeHandler/SchemeHandlerHooks/.";
+
 const OptaStatsContainer = requireNativeComponent('OptaStatsContainer');
 
 /**
@@ -42,6 +44,46 @@ function renderError(message: string, onDismiss: () => void) {
     </View>
   );
 }
+
+schemeHandlerHooks["copa_stats"] = async ({ query, url, onFinish }) => {
+  const packageName = DEFAULT.packageName;
+  const methodName = DEFAULT.methodName;
+  const screenPackage = NativeModules?.[packageName];
+  const method = screenPackage?.[methodName];
+
+  if (!packageName) {
+    logger.warn(`React package name is not set`);
+    onFinish();
+    return;
+  }
+
+  if (!methodName) {
+    logger.warn(`React method name is not set`);
+    onFinish();
+    return;
+  }
+
+  if (!screenPackage) {
+    logger.warn(`Package ${packageName} is not found`);
+    onFinish();
+    return;
+  }
+
+  if (!method) {
+    logger.warn(`Method ${methodName} is not found in the package ${packageName}`);
+    onFinish();
+    return;
+  };
+
+  try {
+    const res = await method({url});
+    logger.info(`Received response from native method ${methodName}`, res);
+    onFinish();
+  } catch (error) {
+    logger.error(`Method ${methodName} the package ${packageName} failed with error ${error}`);
+    onFinish();
+  }
+};
 
 export default NativeScreen = ({ screenData }: Props) => {
   const navigator = useNavigation();


### PR DESCRIPTION
Example url passing on android:

`adb shell am start -a "android.intent.action.VIEW" -d "ca2019://present?screen_id=082ac1b2-783f-4f41-b95a-f4a486a4acd6\&type=all_matches_screen\&team_id=ajab3nmpoltsoeqcuoyi4pwzx"`

Known bug: if app is already on COPA screen, navigation to modal ones won't happen, since QB navigation checks screen ID.
This requires QB update.

I also found high level hooks in RN, we can just register there.

`adb shell am start -a "android.intent.action.VIEW" -d "ca2019://copa_stats?screen_id=082ac1b2-783f-4f41-b95a-f4a486a4acd6\&type=all_matches_screen\&team_id=ajab3nmpoltsoeqcuoyi4pwzx"`

No QB update required for this option.