### PR TITLE
fix: override safeareaview padding if android tablet

### DIFF
--- a/plugins/first-time-user-expirience-screen/src/Components/FirstTimeUserExpirience/index.tsx
+++ b/plugins/first-time-user-expirience-screen/src/Components/FirstTimeUserExpirience/index.tsx
@@ -5,15 +5,8 @@ import React, {
   useMemo,
   useRef,
 } from "react";
-import {
-  Platform,
-  View,
-  SegmentedControlIOSBase,
-  ActivityIndicator,
-} from "react-native";
+import { Platform, ActivityIndicator } from "react-native";
 
-import { isWebBasedPlatform } from "../../Utils/Platform";
-import { useNavigation } from "@applicaster/zapp-react-native-utils/reactHooks/navigation";
 import {
   getRiversProp,
   prepareData,
@@ -21,12 +14,12 @@ import {
   updatePresentedInfo,
   removePresentedInfo,
 } from "./Utils";
-import { getStyles, isHomeScreen } from "../../Utils/Customization";
+import { getStyles } from "../../Utils/Customization";
 import { ComponentsMap } from "@applicaster/zapp-react-native-ui-components/Components/River/ComponentsMap";
 import { SafeAreaView } from "@applicaster/zapp-react-native-ui-components/Components/SafeAreaView";
-import { useDimensions } from "@applicaster/zapp-react-native-utils/reactHooks";
 import { getLocalizations } from "../../Utils/Localizations";
 import { ScreenResolver } from "@applicaster/zapp-react-native-ui-components/Components/ScreenResolver";
+import { isTablet } from "@applicaster/zapp-react-native-utils/reactHooks";
 
 import TopBar from "../TopBar";
 import FloatingButton from "../FloatingButton";
@@ -41,6 +34,9 @@ const logger = createLogger({
   subsystem: BaseSubsystem,
   category: BaseCategories.GENERAL,
 });
+
+const isAndroid = Platform.OS === "android";
+const isAndroidTablet = isAndroid && isTablet;
 
 export default function FirstTimeUserExpirience(props) {
   const [dataSource, setDataSource] = useState<Array<DataModel> | null>(null);
@@ -220,6 +216,7 @@ export default function FirstTimeUserExpirience(props) {
       style={{
         flex: 1,
         backgroundColor: screenStyles?.background_color,
+        ...(isAndroidTablet && { paddingTop: 0 }),
       }}
     >
       {data && renderScreen()}


### PR DESCRIPTION
### Description

This PR is just adding a small override for Android tablets, we are using the SafeAreaView which adds padding to the top and bottom of the view, but we only need it on the bottom in this case so we are just making a minor css change in this PR.


We believe that after [this change](https://github.com/applicaster/QuickBrick/pull/2220) library is correctly adding padding to the top and the bottom of the screen so that we fit the screen and make space for software buttons and status bar.

This PR heavily relies on the changes to the SafeAreaView library in QuickBrick, otherwise the fix won't work.

![Screenshot_1621006645](https://user-images.githubusercontent.com/2348227/118300041-81822a80-b4af-11eb-9d19-301f0ef9be72.png)
![Screenshot_1621006659](https://user-images.githubusercontent.com/2348227/118300048-821ac100-b4af-11eb-9d35-35f1276415ee.png)
