### PR TITLE
fix: applicaster account components export

### DIFF
--- a/plugins/applicaster-account-components/src/index.js
+++ b/plugins/applicaster-account-components/src/index.js
@@ -5,7 +5,7 @@ import LogoutFlow from "./Components/LogoutFlow";
 import SetNewPassword from "./Components/SetNewPassword";
 import SignUp from "./Components/SignUp";
 import LoadingScreen from "./Components/LoadingScreen";
-export default AccountComponent = {
+export default {
   AccountFlow,
   ForgotPassword,
   Login,


### PR DESCRIPTION
### Description

Inplayer is causing build failures because of one of its dependencies. 

### Issue

![second](https://i.gyazo.com/8eda7372fd855357c9e3efc11cc0a3c0.png)

To fix the second issue related to the applicaster-account-components we just had to change out the component was being exported. 
 