### PR TITLE
fix: inplayer deps bumped

### DIFF
--- a/plugins/quick-brick-inplayer-login/manifests/manifest.config.js
+++ b/plugins/quick-brick-inplayer-login/manifests/manifest.config.js
@@ -1210,6 +1210,7 @@ const api = {
     excludedNodeModules: [
       "react-native-dropdownalert",
       "react-native-keyboard-aware-scroll-view",
+      "@applicaster/applicaster-account-components",
     ],
   },
   android: {

--- a/plugins/quick-brick-inplayer-login/package.json
+++ b/plugins/quick-brick-inplayer-login/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@applicaster/applicaster-account-components": "0.1.2",
+    "@applicaster/applicaster-account-components": "0.1.3",
     "@applicaster/quick-brick-parent-lock": "*",
     "@inplayer-org/inplayer.js": "3.11.1",
     "@react-native-community/blur": "3.4.1",


### PR DESCRIPTION
### Description

Inplayer is causing build failures because of one of its dependencies. 


### Issue

@applicaster/applicaster-account-components is using fancy JS that needs to be transpiled:

```
ERROR in /home/circleci/zapp-webOS/node_modules/@applicaster/applicaster-account-components/src/Components/AccountFlow/index.js 20:34
Module parse failed: Unexpected token (20:34)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|   return {
|     ...container,
>     backgroundColor: screenStyles?.background_color,
|   };
| };
```

One way to get around that is by adding it to the excludedNodeModules list. 

That's what I did in this PR, we will need to do a fix in the account components plugin as well, or in the repo as part of a build step.

With this fix finally was able to build GainTV: https://applicaster.monday.com/boards/1139872912/pulses/1272676772
