### PR TITLE
feat: skip notification belonging to already displayed events (tags)

### DIFF
--- a/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/services/APMessagingService.kt
+++ b/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/services/APMessagingService.kt
@@ -98,7 +98,7 @@ class APMessagingService : FirebaseMessagingService() {
             if (message.data.containsKey("groupid")) groupId = message.data["groupid"]
 
             if(!groupId.isNullOrBlank() && !shouldPresent(groupId)) {
-                APLogger.info(TAG, "Notification belongs to the groupid that was already seen, discarding")
+                APLogger.info(TAG, "Notification belongs to the groupid '$groupId' that was already seen, discarding")
                 return
             }
         }

--- a/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/services/APMessagingService.kt
+++ b/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/services/APMessagingService.kt
@@ -79,6 +79,7 @@ class APMessagingService : FirebaseMessagingService() {
         var tag: String? = ""
         var channel: String? = FIREBASE_DEFAULT_CHANNEL_ID
         var image: Uri? = null
+        var groupId: String? = null
 
         if(null != message.notification) {
             APLogger.info(TAG, "The message received had notification attached, using it to retrieve params")
@@ -94,10 +95,10 @@ class APMessagingService : FirebaseMessagingService() {
             if (message.data.containsKey("tag")) tag = message.data["tag"]
             if (message.data.containsKey("android_channel_id")) channel = message.data["android_channel_id"]
             if (message.data.containsKey("image") && !TextUtils.isEmpty(message.data["image"])) image = Uri.parse(message.data["image"])
+            if (message.data.containsKey("groupid")) groupId = message.data["groupid"]
 
-            if(!tag.isNullOrBlank() && !shouldPresent(tag)) {
-                // todo: maybe add a plugin settings on that behavior
-                APLogger.info(TAG, "Notification belongs to the event (tag) that was already seen, discarding")
+            if(!groupId.isNullOrBlank() && !shouldPresent(groupId)) {
+                APLogger.info(TAG, "Notification belongs to the groupid that was already seen, discarding")
                 return
             }
         }
@@ -130,8 +131,8 @@ class APMessagingService : FirebaseMessagingService() {
                 image = image
         )
         notify(notificationFactory, pushMsg)
-        if(!tag.isNullOrBlank()) {
-            storePresented(tag)
+        if(!groupId.isNullOrBlank()) {
+            storePresented(groupId)
         }
     }
 


### PR DESCRIPTION
Skip notifications that belongs to the event where at least one was already displayed.
Tags field is used for now. I also store current time for first time event was handled, so later we can add timeouts.