### PR TITLE
fix: drm key can be null

### DIFF
--- a/plugins/zapp-react-native-theo-player/android/src/main/java/com/theoplayerreactnative/SourceHelper.java
+++ b/plugins/zapp-react-native-theo-player/android/src/main/java/com/theoplayerreactnative/SourceHelper.java
@@ -68,9 +68,9 @@ public class SourceHelper {
                     APLogger.error(TAG, "Unknown stream type " + streamType);
                 }
 
-                if (jsonTypedSource.has("drm")) {
+                JSONObject drm = jsonTypedSource.optJSONObject("drm");
+                if (null != drm && 0 != drm.length()) {
                     DRMConfiguration drmConfiguration;
-                    JSONObject drm = jsonTypedSource.getJSONObject("drm");
                     if(drm.has("integration")) {
                         String integration = drm.getString("integration");
                         if("keyos".equals(integration))


### PR DESCRIPTION
there was no handling for drm key to be present put null. This code was taken from the example and never actually checked for edge cases. Now we do check