### PR TITLE
fix: hack opta nav from feed

### DIFF
--- a/plugins/quick-brick-opta-stats/src/index.js
+++ b/plugins/quick-brick-opta-stats/src/index.js
@@ -7,22 +7,18 @@ import { styles } from "./styles";
 
 import {requireNativeComponent} from 'react-native';
 
+import { useNavigation } from "@applicaster/zapp-react-native-utils/reactHooks/navigation";
+
 
 const OptaStatsContainer = requireNativeComponent('OptaStatsContainer');
 
 const logger = createLogger();
 
-useUrlSchemeHandler = async ({ query, url, onFinish }) => {
+openScreen = async(url, complete) => {
   const packageName = DEFAULT.packageName;
   const methodName = DEFAULT.methodName;
   const screenPackage = NativeModules?.[packageName];
   const method = screenPackage?.[methodName];
-
-  const complete = () => {
-    onFinish((done) => {
-      done();
-    });
-  }
 
   if (!packageName) {
     logger.error(`React package name is not set`);
@@ -57,7 +53,34 @@ useUrlSchemeHandler = async ({ query, url, onFinish }) => {
   complete();
 };
 
-export default StatScreens = ({}) => {
+useUrlSchemeHandler = async ({ query, url, onFinish }) => {
+
+  const complete = () => {
+    onFinish((done) => {
+      done();
+    });
+  }
+  openScreen(url, complete);
+
+};
+
+export default StatScreens = (params: Any) => {
+  const url = params?.screenData?.link?.href;
+  if(url) {
+    logger.info({message: "COPA url", data: {url}});
+    const navigator = useNavigation();
+    const onDismiss = () => {
+      if (navigator.canGoBack()) {
+        logger.info("Dismissed native screen, going back");
+        navigator.goBack();
+      } else {
+        logger.warn("Dismissed native screen, can't go back, trying to go home");
+        navigator.goHome();
+      }
+    };
+    openScreen(url, onDismiss);
+    //return <View style={styles.container}></View>; //fake screen does not work
+  }
   return <OptaStatsContainer style={styles.container}></OptaStatsContainer>
 };
 


### PR DESCRIPTION
Turns out one cant navigate to custom url host handlers from the feeds, so we now add the hack back, and try to rely on entry mappings (which seems to be a proper way) in theory.
But that way you can olny navigate to the screen, so we back to the original fake screen approach there.
But we have issues: the screen is opened 2-3 times (maybe my mistake or its due to the fact that this screen with the same ID is present in home nav?), and we also navigate to stats home screen first as a side effect. Fir for latter but there is a back nav callback that takes us to team info screen where we came from, so it's not that bad.