### PR TITLE
feat: tag notification replace support

### DIFF
--- a/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/services/APMessagingService.kt
+++ b/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/services/APMessagingService.kt
@@ -1,6 +1,9 @@
 package com.applicaster.firebasepushpluginandroid.services
 
+import android.app.NotificationManager
+import android.content.Context
 import android.net.Uri
+import android.os.Build
 import android.provider.Settings
 import android.text.TextUtils
 import androidx.annotation.WorkerThread
@@ -155,9 +158,24 @@ class APMessagingService : FirebaseMessagingService() {
             with(NotificationManagerCompat.from(this@APMessagingService.applicationContext)) {
                 if(pushMessage.tag.isEmpty())
                     notify(notificationFactory.generateNotificationId(), notification)
-                else
-                    notify(pushMessage.tag, notificationFactory.generateNotificationId(), notification)
+                else {
+                    val id = getId(pushMessage.tag)
+                    notify(pushMessage.tag, id, notification)
+                }
             }
         }
+    }
+
+    private fun getId(tag: String): Int {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val notificationManager: NotificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.activeNotifications?.let {
+                val tagged = it.filterNotNull().firstOrNull { tag == it.tag }
+                if(null != tagged) {
+                    return tagged.id
+                }
+            }
+        }
+        return tag.hashCode()
     }
 }

--- a/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/services/APMessagingService.kt
+++ b/plugins/zapp-push-plugin-firebase/android/src/main/java/com/applicaster/firebasepushpluginandroid/services/APMessagingService.kt
@@ -159,14 +159,14 @@ class APMessagingService : FirebaseMessagingService() {
                 if(pushMessage.tag.isEmpty())
                     notify(notificationFactory.generateNotificationId(), notification)
                 else {
-                    val id = getId(pushMessage.tag)
+                    val id = getId(notificationFactory, pushMessage.tag)
                     notify(pushMessage.tag, id, notification)
                 }
             }
         }
     }
 
-    private fun getId(tag: String): Int {
+    private fun getId(notificationFactory: DefaultNotificationFactory, tag: String): Int {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             val notificationManager: NotificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             notificationManager.activeNotifications?.let {
@@ -175,6 +175,7 @@ class APMessagingService : FirebaseMessagingService() {
                     return tagged.id
                 }
             }
+            return notificationFactory.generateNotificationId()
         }
         return tag.hashCode()
     }


### PR DESCRIPTION
Firebase should collapse notifications with the same tag, but it must be implemented manually for data and foreground messages