### PR TITLE
fix: chromecast mediaItem

### DIFF
--- a/plugins/zapp-generic-chromecast/src/CastHandler/CastHandler.js
+++ b/plugins/zapp-generic-chromecast/src/CastHandler/CastHandler.js
@@ -42,8 +42,13 @@ export function CastHandler(props: Props) {
     free: item?.extensions?.free,
   };
 
+  const mediaItem = Object.assign(
+      { ...media, analytics },
+      item?.extensions?.receiverMetaData || {}
+  );
+
   React.useEffect(() => {
-    Cast.castMedia({ ...media, analytics })
+    Cast.castMedia(mediaItem)
       .then(() => {
         Cast.launchExpandedControls();
         navigator.goBack();


### PR DESCRIPTION
## Description: 
We got a problem with sending a media item to be casted to the native module, media item object is default and does not fit for us, because customer's Chromecast receiver player expects additional specific data. 

Expected ZappN metadata should had at least following params (sample from old native impl):
`mediaItem = {isPlayer=true, title=EURO - Die Teams, description=, mediaUrl=vas://puls4-at, isLive=true, streamDuration=0, playPosition=0, customData={"country":"at","clipId":"134"}}`

We implemented hook that fill all these values and need to update the cast handler to pull this properties and send them to chromecast.

[Monday ticket](https://applicaster.monday.com/boards/1141653998/pulses/1352485463?userId=17198506)
