### PR TITLE
feat(Chromecast-Plugin): add a method to get the cast connected device e info

### DIFF
--- a/plugins/zapp-generic-chromecast/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
+++ b/plugins/zapp-generic-chromecast/android/src/main/java/com/reactnative/googlecast/GoogleCastModule.java
@@ -219,7 +219,7 @@ public class GoogleCastModule
     }
 
     @ReactMethod
-    public void getCastDevice(final Promise promise) {
+    public void getConnectedDeviceInfo(final Promise promise) {
         runOnUiQueueThread(() -> {
             if (mCastSession == null) {
                 promise.resolve(null);

--- a/plugins/zapp-generic-chromecast/apple/ios/Bridge/Chromecast/ChromecastManagerBridge.swift
+++ b/plugins/zapp-generic-chromecast/apple/ios/Bridge/Chromecast/ChromecastManagerBridge.swift
@@ -121,18 +121,20 @@ class ChromecastManager: NSObject, RCTBridgeModule {
     @objc public func getConnectedDeviceInfo(_ resolver: @escaping RCTPromiseResolveBlock,
                                    rejecter: @escaping RCTPromiseRejectBlock) {
         DispatchQueue.main.async {
-            guard let currentSession = GCKCastContext.sharedInstance().sessionManager.currentSession else {
-                rejecter("1", "Cast session is not active", nil)
+            
+            guard let pluginInstance = self.pluginInstance else {
+                rejecter("0", "plugin not available", nil)
                 return
             }
             
-            var connctedDeviceInfo = Dictionary<String,Any>()
-            connctedDeviceInfo["id"] = currentSession.device.deviceID
-            connctedDeviceInfo["version"] = currentSession.device.deviceVersion
-            connctedDeviceInfo["name"] = currentSession.device.friendlyName
-            connctedDeviceInfo["model"] = currentSession.device.modelName
-            
-            resolver(connctedDeviceInfo)
+            do {
+                let connctedDeviceInfo = try pluginInstance.connctedDeviceInfo()
+                resolver(connctedDeviceInfo)
+            } catch ChromecastAdapterError.castSessionIsDown {
+                rejecter("1", "The cast session is down, can't find a connected device info", nil)
+            } catch {
+                rejecter("2", "General chromecast problem", nil)
+            }
         }
     }
 

--- a/plugins/zapp-generic-chromecast/apple/ios/Bridge/Chromecast/ChromecastManagerBridge.swift
+++ b/plugins/zapp-generic-chromecast/apple/ios/Bridge/Chromecast/ChromecastManagerBridge.swift
@@ -9,8 +9,6 @@
 import Foundation
 import React
 import ZappCore
-import GoogleCast
-
 
 @objc(RNGoogleCast)
 class ChromecastManager: NSObject, RCTBridgeModule {
@@ -128,8 +126,8 @@ class ChromecastManager: NSObject, RCTBridgeModule {
             }
             
             do {
-                let connctedDeviceInfo = try pluginInstance.connctedDeviceInfo()
-                resolver(connctedDeviceInfo)
+                let connectedDeviceInfo = try pluginInstance.connectedDeviceInfo()
+                resolver(connectedDeviceInfo)
             } catch ChromecastAdapterError.castSessionIsDown {
                 rejecter("1", "The cast session is down, can't find a connected device info", nil)
             } catch {

--- a/plugins/zapp-generic-chromecast/apple/ios/Bridge/Chromecast/ChromecastManagerBridge.swift
+++ b/plugins/zapp-generic-chromecast/apple/ios/Bridge/Chromecast/ChromecastManagerBridge.swift
@@ -122,7 +122,7 @@ class ChromecastManager: NSObject, RCTBridgeModule {
                                    rejecter: @escaping RCTPromiseRejectBlock) {
         DispatchQueue.main.async {
             guard let currentSession = GCKCastContext.sharedInstance().sessionManager.currentSession else {
-                rejecter("1", "cast session is not active", nil)
+                rejecter("1", "Cast session is not active", nil)
                 return
             }
             

--- a/plugins/zapp-generic-chromecast/apple/ios/Bridge/Chromecast/ChromecastManagerBridge.swift
+++ b/plugins/zapp-generic-chromecast/apple/ios/Bridge/Chromecast/ChromecastManagerBridge.swift
@@ -9,6 +9,8 @@
 import Foundation
 import React
 import ZappCore
+import GoogleCast
+
 
 @objc(RNGoogleCast)
 class ChromecastManager: NSObject, RCTBridgeModule {
@@ -113,6 +115,24 @@ class ChromecastManager: NSObject, RCTBridgeModule {
             }
 
             resolver(pluginInstance.getCurrentCastState())
+        }
+    }
+    
+    @objc public func getConnectedDeviceInfo(_ resolver: @escaping RCTPromiseResolveBlock,
+                                   rejecter: @escaping RCTPromiseRejectBlock) {
+        DispatchQueue.main.async {
+            guard let currentSession = GCKCastContext.sharedInstance().sessionManager.currentSession else {
+                rejecter("1", "cast session is not active", nil)
+                return
+            }
+            
+            var connctedDeviceInfo = Dictionary<String,Any>()
+            connctedDeviceInfo["id"] = currentSession.device.deviceID
+            connctedDeviceInfo["version"] = currentSession.device.deviceVersion
+            connctedDeviceInfo["name"] = currentSession.device.friendlyName
+            connctedDeviceInfo["model"] = currentSession.device.modelName
+            
+            resolver(connctedDeviceInfo)
         }
     }
 

--- a/plugins/zapp-generic-chromecast/apple/ios/Bridge/Chromecast/ChromecastManagerBridgeExport.m
+++ b/plugins/zapp-generic-chromecast/apple/ios/Bridge/Chromecast/ChromecastManagerBridgeExport.m
@@ -20,7 +20,7 @@ RCT_EXTERN_METHOD(launchExpandedControls)
 RCT_EXTERN_METHOD(castMedia:(NSDictionary *)params resolver:(RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock) reject);
 RCT_EXTERN_METHOD(hasConnectedCastSession:(RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock) reject);
 RCT_EXTERN_METHOD(getCastState:(RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock) reject);
-
+RCT_EXTERN_METHOD(getConnectedDeviceInfo:(RCTPromiseResolveBlock)resolve rejecter: (RCTPromiseRejectBlock) reject);
 @end
 
 @interface RCT_EXTERN_MODULE(RNGoogleCastEventEmitter, RCTEventEmitter)

--- a/plugins/zapp-generic-chromecast/apple/ios/Extensions/ChromecastAdapter+ChromecastProtocol.swift
+++ b/plugins/zapp-generic-chromecast/apple/ios/Extensions/ChromecastAdapter+ChromecastProtocol.swift
@@ -97,19 +97,19 @@ extension ChromecastAdapter: ChromecastProtocol {
         return GCKCastContext.sharedInstance().sessionManager.currentSession?.device.friendlyName
     }
     
-    public func connctedDeviceInfo() throws -> Dictionary<String,Any>? {
+    public func connectedDeviceInfo() throws -> Dictionary<String,Any>? {
         guard hasConnectedCastSession(),
               let currentSession = GCKCastContext.sharedInstance().sessionManager.currentSession else {
             throw ChromecastAdapterError.castSessionIsDown
         }
         
-        var connctedDeviceInfo = Dictionary<String,Any>()
-        connctedDeviceInfo["id"] = currentSession.device.deviceID
-        connctedDeviceInfo["version"] = currentSession.device.deviceVersion
-        connctedDeviceInfo["name"] = currentSession.device.friendlyName
-        connctedDeviceInfo["model"] = currentSession.device.modelName
+        var connectedDeviceInfo = Dictionary<String,Any>()
+        connectedDeviceInfo["id"] = currentSession.device.deviceID
+        connectedDeviceInfo["version"] = currentSession.device.deviceVersion
+        connectedDeviceInfo["name"] = currentSession.device.friendlyName
+        connectedDeviceInfo["model"] = currentSession.device.modelName
         
-        return connctedDeviceInfo
+        return connectedDeviceInfo
     }
     
     public func createChromecastButton(frame: CGRect,


### PR DESCRIPTION
We want to add a new native module to the Chromecast plugin that gives the currently connected device metadata. 
This enables us to create custom Chromecast views in react native.

The current metadata that will be available is:
* deviceID
* deviceVersion
* friendlyName
* modelName

In the future, we would be able to add more params such as volume and more.

 