### PR TITLE
fix: copy proguard rules from aar

### DIFF
--- a/plugins/zapp-analytics-plugin-gemius/android/proguard-rules.pro
+++ b/plugins/zapp-analytics-plugin-gemius/android/proguard-rules.pro
@@ -1,0 +1,11 @@
+# Keep the Gemius events classes
+-keep class com.gemius.sdk.** { *; }
+-keep enum com.gemius.sdk.** { *; }
+
+# Prevent errors while using gson
+-keepattributes Signature
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}


### PR DESCRIPTION
Proguard rules are not picked up by gradle from aar libraries linked to plugin libraries projects.
Copy the rules for now to the plugin library level.