### PR TITLE
feat: adding support for Network framework instead of Reachability

### DIFF
--- a/plugins/zapp-apple/apple/ZappApple.podspec.json
+++ b/plugins/zapp-apple/apple/ZappApple.podspec.json
@@ -43,9 +43,6 @@
   },
   "dependencies": {
     "ZappCore": [],
-    "ReachabilitySwift": [
-      "= 5.0.0"
-    ],
     "DeviceKit": [
       "= 4.3.0"
     ],

--- a/plugins/zapp-apple/apple/universal/Helpers/Reachability/ReachabilityManager.swift
+++ b/plugins/zapp-apple/apple/universal/Helpers/Reachability/ReachabilityManager.swift
@@ -10,16 +10,17 @@ import Foundation
 import Network
 
 class ReachabilityManager {
-    let monitor: NWPathMonitor = NWPathMonitor()
+    let monitor: NWPathMonitor?
     var delegate: ReachabilityManagerDelegate
 
     init(delegate: ReachabilityManagerDelegate) {
         self.delegate = delegate
+        self.monitor = NWPathMonitor()
         startObserve()
     }
 
     func startObserve() {
-        monitor.pathUpdateHandler = { path in
+        monitor?.pathUpdateHandler = { path in
             if path.status == .satisfied {
                 let interfaceTypes = path.availableInterfaces.map { $0.type }
                 self.delegate.reachabilityChanged(.connected(interfaceTypes))
@@ -29,6 +30,6 @@ class ReachabilityManager {
         }
         
         let queue = DispatchQueue(label: "ReachabilityMonitor")
-        monitor.start(queue: queue)
+        monitor?.start(queue: queue)
     }
 }

--- a/plugins/zapp-apple/apple/universal/Helpers/Reachability/ReachabilityManager.swift
+++ b/plugins/zapp-apple/apple/universal/Helpers/Reachability/ReachabilityManager.swift
@@ -22,7 +22,7 @@ class ReachabilityManager {
     func startObserve() {
         monitor?.pathUpdateHandler = { path in
             if path.status == .satisfied {
-                let interfaceTypes = path.availableInterfaces.map { $0.type }
+                let interfaceTypes = path.availableInterfaces.map(\.type)
                 self.delegate.reachabilityChanged(.connected(interfaceTypes))
             } else {
                 self.delegate.reachabilityChanged(.disconnected)

--- a/plugins/zapp-apple/apple/universal/Helpers/Reachability/ReachabilityManagerDelegate.swift
+++ b/plugins/zapp-apple/apple/universal/Helpers/Reachability/ReachabilityManagerDelegate.swift
@@ -7,8 +7,35 @@
 //
 
 import Foundation
-import Reachability
+import Network
 
 protocol ReachabilityManagerDelegate {
-    func reachabilityChanged(connection: Reachability.Connection)
+    func reachabilityChanged(_ state: ReachabilityState)
+}
+
+public enum ReachabilityState: Equatable {
+    case connected(_ interfaces: [NWInterface.InterfaceType])
+    case disconnected
+
+    public static func == (lhs: ReachabilityState, rhs: ReachabilityState) -> Bool {
+        switch (lhs, rhs) {
+        case let (.connected(a1), .connected(a2)):
+            return a1 == a2
+        case (.disconnected, .disconnected):
+            return true
+        default:
+            return false
+        }
+    }
+
+    public var description: String {
+        var retValue = ""
+        switch self {
+        case .connected:
+            retValue = "connected"
+        case .disconnected:
+            retValue = "disconnected"
+        }
+        return retValue
+    }
 }

--- a/plugins/zapp-apple/apple/universal/RootController/FacadeConnector/RootController+FacadeConnectorConnectivityProtocol.swift
+++ b/plugins/zapp-apple/apple/universal/RootController/FacadeConnector/RootController+FacadeConnectorConnectivityProtocol.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Reachability
 import ZappCore
 
 extension RootController: FacadeConnectorConnnectivityProtocol {
@@ -14,7 +13,7 @@ extension RootController: FacadeConnectorConnnectivityProtocol {
         var revValue = false
 
         switch currentConnection {
-        case .wifi, .cellular:
+        case .connected:
             revValue = true
         default:
             break
@@ -30,16 +29,15 @@ extension RootController: FacadeConnectorConnnectivityProtocol {
     public func getCurrentConnectivityState() -> ConnectivityState {
         var retValue: ConnectivityState = .cellular
 
-        guard let connection = currentConnection else {
-            return retValue
-        }
-
-        switch connection {
-        case .cellular:
-            retValue = .cellular
-        case .wifi:
-            retValue = .wifi
-        case .unavailable, .none:
+        switch currentConnection {
+        case let .connected(connections):
+            if connections.contains(.cellular) {
+                retValue = .cellular
+            }
+            else {
+                retValue = .wifi
+            }
+        case .disconnected:
             retValue = .offline
         }
         return retValue

--- a/plugins/zapp-apple/apple/universal/RootController/RootController+ReachabilityManagerDelegate.swift
+++ b/plugins/zapp-apple/apple/universal/RootController/RootController+ReachabilityManagerDelegate.swift
@@ -7,29 +7,25 @@
 //
 
 import Foundation
-import Reachability
 import ZappCore
 
 extension RootController: ReachabilityManagerDelegate {
-    func reachabilityChanged(connection: Reachability.Connection) {
-        switch connection {
-        case .wifi, .cellular:
-            if let currentConnection = currentConnection,
-               currentConnection == .unavailable {
+    func reachabilityChanged(_ state: ReachabilityState) {
+        switch state {
+        case .connected(_):
+            if currentConnection == .disconnected {
                 forceReloadApplication()
             }
-        case .none:
-            showInternetError()
-        case .unavailable:
+        case .disconnected:
             showInternetError()
         }
-        currentConnection = connection
+        currentConnection = state
 
         updateConnectivityListeners()
         
         let event = EventsBus.Event(type: EventsBusType(.reachabilityChanged),
                                     source: logger?.subsystem,
-                                    data: ["connection": connection.description])
+                                    data: ["connection": currentConnection.description])
         EventsBus.post(event)
     }
 


### PR DESCRIPTION
adding support for Network framework instead of Reachability

Apple’s Network framework provides a number of useful classes for working with network data, including one specifically designed to monitor network accessibility: NWPathMonitor. If you ever used Apple’s older Reachability system, NWPathMonitor replaces it fully.

https://www.hackingwithswift.com/example-code/networking/how-to-check-for-internet-connectivity-using-nwpathmonitor