### PR TITLE
bug: fix genius analytics crash

### DIFF
--- a/plugins/zapp-analytics-plugin-gemius/apple/universal/GemiusAnalytics+ScreenEvents.swift
+++ b/plugins/zapp-analytics-plugin-gemius/apple/universal/GemiusAnalytics+ScreenEvents.swift
@@ -67,7 +67,9 @@ extension GemiusAnalytics {
         event.eventType = type
         event.scriptIdentifier = scriptIdentifier
         for (key, value) in params {
-            event.addExtraParameter(key, value: value)
+            if key.count > 0 && value.count > 0 {
+                event.addExtraParameter(key, value: value)
+            }
         }
         event.send()
 


### PR DESCRIPTION
If value is empty, Genius SDK crashing the app