### PR TITLE
Feat/onetrust button screen

### DIFF
--- a/plugins/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec.json
+++ b/plugins/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ZappCmpOneTrust",
-  "version": "0.2.3-beta.2",
+  "version": "0.2.3-beta.3",
   "platforms": {
     "ios": "12.0",
     "tvos": "12.0"
@@ -12,7 +12,7 @@
   "authors": "Applicaster LTD.",
   "source": {
     "git": "https://github.com/applicaster/Zapp-Frameworks.git",
-    "tag": "@@applicaster/applicaster-cmp-onetrust/0.2.3-beta.2"
+    "tag": "@@applicaster/applicaster-cmp-onetrust/0.2.3-beta.3"
   },
   "requires_arc": true,
   "swift_versions": "5.1",

--- a/plugins/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec.json
+++ b/plugins/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ZappCmpOneTrust",
-  "version": "0.2.3-beta.0",
+  "version": "0.2.3-beta.1",
   "platforms": {
     "ios": "12.0",
     "tvos": "12.0"
@@ -12,7 +12,7 @@
   "authors": "Applicaster LTD.",
   "source": {
     "git": "https://github.com/applicaster/Zapp-Frameworks.git",
-    "tag": "@@applicaster/applicaster-cmp-onetrust/0.2.3-beta.0"
+    "tag": "@@applicaster/applicaster-cmp-onetrust/0.2.3-beta.1"
   },
   "requires_arc": true,
   "swift_versions": "5.1",

--- a/plugins/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec.json
+++ b/plugins/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ZappCmpOneTrust",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "platforms": {
     "ios": "12.0",
     "tvos": "12.0"
@@ -12,7 +12,7 @@
   "authors": "Applicaster LTD.",
   "source": {
     "git": "https://github.com/applicaster/Zapp-Frameworks.git",
-    "tag": "@@applicaster/applicaster-cmp-onetrust/0.2.1"
+    "tag": "@@applicaster/applicaster-cmp-onetrust/0.2.2"
   },
   "requires_arc": true,
   "swift_versions": "5.1",

--- a/plugins/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec.json
+++ b/plugins/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ZappCmpOneTrust",
-  "version": "0.2.2",
+  "version": "0.2.3-beta.0",
   "platforms": {
     "ios": "12.0",
     "tvos": "12.0"
@@ -12,7 +12,7 @@
   "authors": "Applicaster LTD.",
   "source": {
     "git": "https://github.com/applicaster/Zapp-Frameworks.git",
-    "tag": "@@applicaster/applicaster-cmp-onetrust/0.2.2"
+    "tag": "@@applicaster/applicaster-cmp-onetrust/0.2.3-beta.0"
   },
   "requires_arc": true,
   "swift_versions": "5.1",

--- a/plugins/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec.json
+++ b/plugins/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ZappCmpOneTrust",
-  "version": "0.2.3-beta.1",
+  "version": "0.2.3-beta.2",
   "platforms": {
     "ios": "12.0",
     "tvos": "12.0"
@@ -12,7 +12,7 @@
   "authors": "Applicaster LTD.",
   "source": {
     "git": "https://github.com/applicaster/Zapp-Frameworks.git",
-    "tag": "@@applicaster/applicaster-cmp-onetrust/0.2.3-beta.1"
+    "tag": "@@applicaster/applicaster-cmp-onetrust/0.2.3-beta.2"
   },
   "requires_arc": true,
   "swift_versions": "5.1",

--- a/plugins/applicaster-cmp-onetrust/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/amazon_fire_tv_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.1"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.2"
   ],
   "targets": [
     "tv"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "manifest_version": "0.2.3-beta.1",
-  "dependency_version": "0.2.3-beta.1",
+  "manifest_version": "0.2.3-beta.2",
+  "dependency_version": "0.2.3-beta.2",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"
@@ -161,9 +161,21 @@
             "initial_value": "rgba(84, 90, 92, 1)"
           },
           {
+            "key": "intro_button_focused_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Intro Button Focused Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
             "key": "intro_button_backgroundcolor",
             "type": "color_picker_rgba",
             "label_tooltip": "Background Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
+            "key": "intro_button_focused_backgroundcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Background Color for Intro Button Focused Text",
             "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]

--- a/plugins/applicaster-cmp-onetrust/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/amazon_fire_tv_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.0"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.1"
   ],
   "targets": [
     "tv"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "manifest_version": "0.2.3-beta.0",
-  "dependency_version": "0.2.3-beta.0",
+  "manifest_version": "0.2.3-beta.1",
+  "dependency_version": "0.2.3-beta.1",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"

--- a/plugins/applicaster-cmp-onetrust/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/amazon_fire_tv_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.1"
+    "@applicaster/applicaster-cmp-onetrust@0.2.2"
   ],
   "targets": [
     "tv"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "manifest_version": "0.2.1",
-  "dependency_version": "0.2.1",
+  "manifest_version": "0.2.2",
+  "dependency_version": "0.2.2",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"
@@ -106,6 +106,59 @@
           {
             "key": "styles/title_text_data_key",
             "condition_value": "screen"
+          }
+        ]
+      },
+      {
+        "key": "show_intro_screen",
+        "type": "switch",
+        "label": "Show intro screen before open native screen",
+        "label_tooltip": "Enables the intro screen.",
+        "initial_value": "false"
+      },
+      {
+        "group": true,
+        "label": "Intro Screen Design and Text",
+        "tooltip": "These fields affect the design of the intro screen.",
+        "folded": true,
+        "fields": [
+          {
+            "key": "intro_button_text",
+            "type": "text_input",
+            "label": "Button Text",
+            "label_tooltip": "Text in the button of the intro screen",
+            "initial_value": "Preferences",
+            "placeholder": "Preferences"
+          },
+          {
+            "key": "intro_button_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Intro Button Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "intro_button_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Intro Button Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "intro_button_font_samsung",
+            "type": "samsung_tv_font_selector",
+            "label_tooltip": "Font for Intro Button Text for Samsung TV.",
+            "initial_value": "Times New Roman"
+          },
+          {
+            "key": "intro_button_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Intro Button Text.",
+            "initial_value": "41"
+          },
+          {
+            "key": "intro_button_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]
       }

--- a/plugins/applicaster-cmp-onetrust/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/amazon_fire_tv_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.2"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.3"
   ],
   "targets": [
     "tv"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "manifest_version": "0.2.3-beta.2",
-  "dependency_version": "0.2.3-beta.2",
+  "manifest_version": "0.2.3-beta.3",
+  "dependency_version": "0.2.3-beta.3",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"

--- a/plugins/applicaster-cmp-onetrust/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/amazon_fire_tv_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.2"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.0"
   ],
   "targets": [
     "tv"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "manifest_version": "0.2.2",
-  "dependency_version": "0.2.2",
+  "manifest_version": "0.2.3-beta.0",
+  "dependency_version": "0.2.3-beta.0",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"
@@ -158,6 +158,12 @@
             "key": "intro_button_fontcolor",
             "type": "color_picker_rgba",
             "label_tooltip": "Font Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
+            "key": "intro_button_backgroundcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Background Color for Intro Button Text.",
             "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]

--- a/plugins/applicaster-cmp-onetrust/manifests/android_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/android_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.1"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.2"
   ],
   "targets": [
     "mobile"
   ],
   "platform": "android_for_quickbrick",
-  "manifest_version": "0.2.3-beta.1",
-  "dependency_version": "0.2.3-beta.1",
+  "manifest_version": "0.2.3-beta.2",
+  "dependency_version": "0.2.3-beta.2",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"
@@ -161,9 +161,21 @@
             "initial_value": "rgba(84, 90, 92, 1)"
           },
           {
+            "key": "intro_button_focused_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Intro Button Focused Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
             "key": "intro_button_backgroundcolor",
             "type": "color_picker_rgba",
             "label_tooltip": "Background Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
+            "key": "intro_button_focused_backgroundcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Background Color for Intro Button Focused Text",
             "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]

--- a/plugins/applicaster-cmp-onetrust/manifests/android_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/android_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.0"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.1"
   ],
   "targets": [
     "mobile"
   ],
   "platform": "android_for_quickbrick",
-  "manifest_version": "0.2.3-beta.0",
-  "dependency_version": "0.2.3-beta.0",
+  "manifest_version": "0.2.3-beta.1",
+  "dependency_version": "0.2.3-beta.1",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"

--- a/plugins/applicaster-cmp-onetrust/manifests/android_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/android_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.2"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.3"
   ],
   "targets": [
     "mobile"
   ],
   "platform": "android_for_quickbrick",
-  "manifest_version": "0.2.3-beta.2",
-  "dependency_version": "0.2.3-beta.2",
+  "manifest_version": "0.2.3-beta.3",
+  "dependency_version": "0.2.3-beta.3",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"

--- a/plugins/applicaster-cmp-onetrust/manifests/android_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/android_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.1"
+    "@applicaster/applicaster-cmp-onetrust@0.2.2"
   ],
   "targets": [
     "mobile"
   ],
   "platform": "android_for_quickbrick",
-  "manifest_version": "0.2.1",
-  "dependency_version": "0.2.1",
+  "manifest_version": "0.2.2",
+  "dependency_version": "0.2.2",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"
@@ -106,6 +106,59 @@
           {
             "key": "styles/title_text_data_key",
             "condition_value": "screen"
+          }
+        ]
+      },
+      {
+        "key": "show_intro_screen",
+        "type": "switch",
+        "label": "Show intro screen before open native screen",
+        "label_tooltip": "Enables the intro screen.",
+        "initial_value": "false"
+      },
+      {
+        "group": true,
+        "label": "Intro Screen Design and Text",
+        "tooltip": "These fields affect the design of the intro screen.",
+        "folded": true,
+        "fields": [
+          {
+            "key": "intro_button_text",
+            "type": "text_input",
+            "label": "Button Text",
+            "label_tooltip": "Text in the button of the intro screen",
+            "initial_value": "Preferences",
+            "placeholder": "Preferences"
+          },
+          {
+            "key": "intro_button_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Intro Button Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "intro_button_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Intro Button Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "intro_button_font_samsung",
+            "type": "samsung_tv_font_selector",
+            "label_tooltip": "Font for Intro Button Text for Samsung TV.",
+            "initial_value": "Times New Roman"
+          },
+          {
+            "key": "intro_button_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Intro Button Text.",
+            "initial_value": "41"
+          },
+          {
+            "key": "intro_button_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]
       }

--- a/plugins/applicaster-cmp-onetrust/manifests/android_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/android_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.2"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.0"
   ],
   "targets": [
     "mobile"
   ],
   "platform": "android_for_quickbrick",
-  "manifest_version": "0.2.2",
-  "dependency_version": "0.2.2",
+  "manifest_version": "0.2.3-beta.0",
+  "dependency_version": "0.2.3-beta.0",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"
@@ -158,6 +158,12 @@
             "key": "intro_button_fontcolor",
             "type": "color_picker_rgba",
             "label_tooltip": "Font Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
+            "key": "intro_button_backgroundcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Background Color for Intro Button Text.",
             "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]

--- a/plugins/applicaster-cmp-onetrust/manifests/android_tv_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/android_tv_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.0"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.1"
   ],
   "targets": [
     "tv"
   ],
   "platform": "android_tv_for_quickbrick",
-  "manifest_version": "0.2.3-beta.0",
-  "dependency_version": "0.2.3-beta.0",
+  "manifest_version": "0.2.3-beta.1",
+  "dependency_version": "0.2.3-beta.1",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"

--- a/plugins/applicaster-cmp-onetrust/manifests/android_tv_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/android_tv_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.1"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.2"
   ],
   "targets": [
     "tv"
   ],
   "platform": "android_tv_for_quickbrick",
-  "manifest_version": "0.2.3-beta.1",
-  "dependency_version": "0.2.3-beta.1",
+  "manifest_version": "0.2.3-beta.2",
+  "dependency_version": "0.2.3-beta.2",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"
@@ -161,9 +161,21 @@
             "initial_value": "rgba(84, 90, 92, 1)"
           },
           {
+            "key": "intro_button_focused_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Intro Button Focused Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
             "key": "intro_button_backgroundcolor",
             "type": "color_picker_rgba",
             "label_tooltip": "Background Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
+            "key": "intro_button_focused_backgroundcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Background Color for Intro Button Focused Text",
             "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]

--- a/plugins/applicaster-cmp-onetrust/manifests/android_tv_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/android_tv_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.1"
+    "@applicaster/applicaster-cmp-onetrust@0.2.2"
   ],
   "targets": [
     "tv"
   ],
   "platform": "android_tv_for_quickbrick",
-  "manifest_version": "0.2.1",
-  "dependency_version": "0.2.1",
+  "manifest_version": "0.2.2",
+  "dependency_version": "0.2.2",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"
@@ -106,6 +106,59 @@
           {
             "key": "styles/title_text_data_key",
             "condition_value": "screen"
+          }
+        ]
+      },
+      {
+        "key": "show_intro_screen",
+        "type": "switch",
+        "label": "Show intro screen before open native screen",
+        "label_tooltip": "Enables the intro screen.",
+        "initial_value": "false"
+      },
+      {
+        "group": true,
+        "label": "Intro Screen Design and Text",
+        "tooltip": "These fields affect the design of the intro screen.",
+        "folded": true,
+        "fields": [
+          {
+            "key": "intro_button_text",
+            "type": "text_input",
+            "label": "Button Text",
+            "label_tooltip": "Text in the button of the intro screen",
+            "initial_value": "Preferences",
+            "placeholder": "Preferences"
+          },
+          {
+            "key": "intro_button_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Intro Button Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "intro_button_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Intro Button Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "intro_button_font_samsung",
+            "type": "samsung_tv_font_selector",
+            "label_tooltip": "Font for Intro Button Text for Samsung TV.",
+            "initial_value": "Times New Roman"
+          },
+          {
+            "key": "intro_button_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Intro Button Text.",
+            "initial_value": "41"
+          },
+          {
+            "key": "intro_button_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]
       }

--- a/plugins/applicaster-cmp-onetrust/manifests/android_tv_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/android_tv_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.2"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.0"
   ],
   "targets": [
     "tv"
   ],
   "platform": "android_tv_for_quickbrick",
-  "manifest_version": "0.2.2",
-  "dependency_version": "0.2.2",
+  "manifest_version": "0.2.3-beta.0",
+  "dependency_version": "0.2.3-beta.0",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"
@@ -158,6 +158,12 @@
             "key": "intro_button_fontcolor",
             "type": "color_picker_rgba",
             "label_tooltip": "Font Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
+            "key": "intro_button_backgroundcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Background Color for Intro Button Text.",
             "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]

--- a/plugins/applicaster-cmp-onetrust/manifests/android_tv_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/android_tv_for_quickbrick.json
@@ -48,14 +48,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.2"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.3"
   ],
   "targets": [
     "tv"
   ],
   "platform": "android_tv_for_quickbrick",
-  "manifest_version": "0.2.3-beta.2",
-  "dependency_version": "0.2.3-beta.2",
+  "manifest_version": "0.2.3-beta.3",
+  "dependency_version": "0.2.3-beta.3",
   "project_dependencies": [
     {
       "applicaster-cmp-onetrust": "node_modules/@applicaster/applicaster-cmp-onetrust/android"

--- a/plugins/applicaster-cmp-onetrust/manifests/ios_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/ios_for_quickbrick.json
@@ -55,14 +55,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.1"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.2"
   ],
   "targets": [
     "mobile"
   ],
   "platform": "ios_for_quickbrick",
-  "manifest_version": "0.2.3-beta.1",
-  "dependency_version": "0.2.3-beta.1",
+  "manifest_version": "0.2.3-beta.2",
+  "dependency_version": "0.2.3-beta.2",
   "extra_dependencies": [
     {
       "ZappCmpOneTrust": ":path => './node_modules/@applicaster/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec'"
@@ -168,9 +168,21 @@
             "initial_value": "rgba(84, 90, 92, 1)"
           },
           {
+            "key": "intro_button_focused_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Intro Button Focused Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
             "key": "intro_button_backgroundcolor",
             "type": "color_picker_rgba",
             "label_tooltip": "Background Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
+            "key": "intro_button_focused_backgroundcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Background Color for Intro Button Focused Text",
             "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]

--- a/plugins/applicaster-cmp-onetrust/manifests/ios_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/ios_for_quickbrick.json
@@ -55,14 +55,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.0"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.1"
   ],
   "targets": [
     "mobile"
   ],
   "platform": "ios_for_quickbrick",
-  "manifest_version": "0.2.3-beta.0",
-  "dependency_version": "0.2.3-beta.0",
+  "manifest_version": "0.2.3-beta.1",
+  "dependency_version": "0.2.3-beta.1",
   "extra_dependencies": [
     {
       "ZappCmpOneTrust": ":path => './node_modules/@applicaster/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec'"

--- a/plugins/applicaster-cmp-onetrust/manifests/ios_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/ios_for_quickbrick.json
@@ -55,14 +55,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.2"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.3"
   ],
   "targets": [
     "mobile"
   ],
   "platform": "ios_for_quickbrick",
-  "manifest_version": "0.2.3-beta.2",
-  "dependency_version": "0.2.3-beta.2",
+  "manifest_version": "0.2.3-beta.3",
+  "dependency_version": "0.2.3-beta.3",
   "extra_dependencies": [
     {
       "ZappCmpOneTrust": ":path => './node_modules/@applicaster/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec'"

--- a/plugins/applicaster-cmp-onetrust/manifests/ios_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/ios_for_quickbrick.json
@@ -55,14 +55,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.1"
+    "@applicaster/applicaster-cmp-onetrust@0.2.2"
   ],
   "targets": [
     "mobile"
   ],
   "platform": "ios_for_quickbrick",
-  "manifest_version": "0.2.1",
-  "dependency_version": "0.2.1",
+  "manifest_version": "0.2.2",
+  "dependency_version": "0.2.2",
   "extra_dependencies": [
     {
       "ZappCmpOneTrust": ":path => './node_modules/@applicaster/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec'"
@@ -113,6 +113,59 @@
           {
             "key": "styles/title_text_data_key",
             "condition_value": "screen"
+          }
+        ]
+      },
+      {
+        "key": "show_intro_screen",
+        "type": "switch",
+        "label": "Show intro screen before open native screen",
+        "label_tooltip": "Enables the intro screen.",
+        "initial_value": "false"
+      },
+      {
+        "group": true,
+        "label": "Intro Screen Design and Text",
+        "tooltip": "These fields affect the design of the intro screen.",
+        "folded": true,
+        "fields": [
+          {
+            "key": "intro_button_text",
+            "type": "text_input",
+            "label": "Button Text",
+            "label_tooltip": "Text in the button of the intro screen",
+            "initial_value": "Preferences",
+            "placeholder": "Preferences"
+          },
+          {
+            "key": "intro_button_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Intro Button Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "intro_button_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Intro Button Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "intro_button_font_samsung",
+            "type": "samsung_tv_font_selector",
+            "label_tooltip": "Font for Intro Button Text for Samsung TV.",
+            "initial_value": "Times New Roman"
+          },
+          {
+            "key": "intro_button_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Intro Button Text.",
+            "initial_value": "41"
+          },
+          {
+            "key": "intro_button_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]
       }

--- a/plugins/applicaster-cmp-onetrust/manifests/ios_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/ios_for_quickbrick.json
@@ -55,14 +55,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.2"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.0"
   ],
   "targets": [
     "mobile"
   ],
   "platform": "ios_for_quickbrick",
-  "manifest_version": "0.2.2",
-  "dependency_version": "0.2.2",
+  "manifest_version": "0.2.3-beta.0",
+  "dependency_version": "0.2.3-beta.0",
   "extra_dependencies": [
     {
       "ZappCmpOneTrust": ":path => './node_modules/@applicaster/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec'"
@@ -165,6 +165,12 @@
             "key": "intro_button_fontcolor",
             "type": "color_picker_rgba",
             "label_tooltip": "Font Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
+            "key": "intro_button_backgroundcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Background Color for Intro Button Text.",
             "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]

--- a/plugins/applicaster-cmp-onetrust/manifests/manifest.config.js
+++ b/plugins/applicaster-cmp-onetrust/manifests/manifest.config.js
@@ -125,6 +125,12 @@ const general = {
           label_tooltip: "Font Color for Intro Button Text.",
           initial_value: "rgba(84, 90, 92, 1)",
         },
+        {
+          key: "intro_button_backgroundcolor",
+          type: "color_picker_rgba",
+          label_tooltip: "Background Color for Intro Button Text.",
+          initial_value: "rgba(84, 90, 92, 1)",
+        },
       ]
     }
   ],

--- a/plugins/applicaster-cmp-onetrust/manifests/manifest.config.js
+++ b/plugins/applicaster-cmp-onetrust/manifests/manifest.config.js
@@ -126,9 +126,21 @@ const general = {
           initial_value: "rgba(84, 90, 92, 1)",
         },
         {
+          key: "intro_button_focused_fontcolor",
+          type: "color_picker_rgba",
+          label_tooltip: "Font Color for Intro Button Focused Text.",
+          initial_value: "rgba(84, 90, 92, 1)",
+        },
+        {
           key: "intro_button_backgroundcolor",
           type: "color_picker_rgba",
           label_tooltip: "Background Color for Intro Button Text.",
+          initial_value: "rgba(84, 90, 92, 1)",
+        },
+        {
+          key: "intro_button_focused_backgroundcolor",
+          type: "color_picker_rgba",
+          label_tooltip: "Background Color for Intro Button Focused Text",
           initial_value: "rgba(84, 90, 92, 1)",
         },
       ]

--- a/plugins/applicaster-cmp-onetrust/manifests/manifest.config.js
+++ b/plugins/applicaster-cmp-onetrust/manifests/manifest.config.js
@@ -73,6 +73,60 @@ const general = {
         },
       ],
     },
+    {
+      key: "show_intro_screen",
+      type: "switch",
+      label: "Show intro screen before open native screen",
+      label_tooltip: "Enables the intro screen.",
+      initial_value: "false"
+    },
+    {
+      group: true,
+      label: "Intro Screen Design and Text",
+      tooltip: "These fields affect the design of the intro screen.",
+      folded: true,
+      fields: [
+        {
+          key: "intro_button_text",
+          type: "text_input",
+          label: "Button Text",
+          label_tooltip:
+            "Text in the button of the intro screen",
+          initial_value: "Preferences",
+          placeholder: "Preferences",
+        },
+        {
+          key: "intro_button_font_tvos",
+          type: "tvos_font_selector",
+          label_tooltip: "Font for Intro Button Text for TvOS.",
+          initial_value: "Helvetica-Bold",
+        },
+        {
+          key: "intro_button_font_android",
+          type: "android_font_selector",
+          label_tooltip: "Font for Intro Button Text for Android TV.",
+          initial_value: "Roboto-Bold",
+        },
+        {
+          key: "intro_button_font_samsung",
+          type: "samsung_tv_font_selector",
+          label_tooltip: "Font for Intro Button Text for Samsung TV.",
+          initial_value: "Times New Roman",
+        },
+        {
+          key: "intro_button_fontsize",
+          type: "number_input",
+          label_tooltip: "Font Size for Intro Button Text.",
+          initial_value: "41",
+        },
+        {
+          key: "intro_button_fontcolor",
+          type: "color_picker_rgba",
+          label_tooltip: "Font Color for Intro Button Text.",
+          initial_value: "rgba(84, 90, 92, 1)",
+        },
+      ]
+    }
   ],
 };
 

--- a/plugins/applicaster-cmp-onetrust/manifests/tvos_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/tvos_for_quickbrick.json
@@ -55,14 +55,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.2"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.0"
   ],
   "targets": [
     "tv"
   ],
   "platform": "tvos_for_quickbrick",
-  "manifest_version": "0.2.2",
-  "dependency_version": "0.2.2",
+  "manifest_version": "0.2.3-beta.0",
+  "dependency_version": "0.2.3-beta.0",
   "extra_dependencies": [
     {
       "ZappCmpOneTrust": ":path => './node_modules/@applicaster/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec'"
@@ -165,6 +165,12 @@
             "key": "intro_button_fontcolor",
             "type": "color_picker_rgba",
             "label_tooltip": "Font Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
+            "key": "intro_button_backgroundcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Background Color for Intro Button Text.",
             "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]

--- a/plugins/applicaster-cmp-onetrust/manifests/tvos_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/tvos_for_quickbrick.json
@@ -55,14 +55,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.0"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.1"
   ],
   "targets": [
     "tv"
   ],
   "platform": "tvos_for_quickbrick",
-  "manifest_version": "0.2.3-beta.0",
-  "dependency_version": "0.2.3-beta.0",
+  "manifest_version": "0.2.3-beta.1",
+  "dependency_version": "0.2.3-beta.1",
   "extra_dependencies": [
     {
       "ZappCmpOneTrust": ":path => './node_modules/@applicaster/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec'"

--- a/plugins/applicaster-cmp-onetrust/manifests/tvos_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/tvos_for_quickbrick.json
@@ -55,14 +55,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.1"
+    "@applicaster/applicaster-cmp-onetrust@0.2.2"
   ],
   "targets": [
     "tv"
   ],
   "platform": "tvos_for_quickbrick",
-  "manifest_version": "0.2.1",
-  "dependency_version": "0.2.1",
+  "manifest_version": "0.2.2",
+  "dependency_version": "0.2.2",
   "extra_dependencies": [
     {
       "ZappCmpOneTrust": ":path => './node_modules/@applicaster/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec'"
@@ -113,6 +113,59 @@
           {
             "key": "styles/title_text_data_key",
             "condition_value": "screen"
+          }
+        ]
+      },
+      {
+        "key": "show_intro_screen",
+        "type": "switch",
+        "label": "Show intro screen before open native screen",
+        "label_tooltip": "Enables the intro screen.",
+        "initial_value": "false"
+      },
+      {
+        "group": true,
+        "label": "Intro Screen Design and Text",
+        "tooltip": "These fields affect the design of the intro screen.",
+        "folded": true,
+        "fields": [
+          {
+            "key": "intro_button_text",
+            "type": "text_input",
+            "label": "Button Text",
+            "label_tooltip": "Text in the button of the intro screen",
+            "initial_value": "Preferences",
+            "placeholder": "Preferences"
+          },
+          {
+            "key": "intro_button_font_tvos",
+            "type": "tvos_font_selector",
+            "label_tooltip": "Font for Intro Button Text for TvOS.",
+            "initial_value": "Helvetica-Bold"
+          },
+          {
+            "key": "intro_button_font_android",
+            "type": "android_font_selector",
+            "label_tooltip": "Font for Intro Button Text for Android TV.",
+            "initial_value": "Roboto-Bold"
+          },
+          {
+            "key": "intro_button_font_samsung",
+            "type": "samsung_tv_font_selector",
+            "label_tooltip": "Font for Intro Button Text for Samsung TV.",
+            "initial_value": "Times New Roman"
+          },
+          {
+            "key": "intro_button_fontsize",
+            "type": "number_input",
+            "label_tooltip": "Font Size for Intro Button Text.",
+            "initial_value": "41"
+          },
+          {
+            "key": "intro_button_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]
       }

--- a/plugins/applicaster-cmp-onetrust/manifests/tvos_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/tvos_for_quickbrick.json
@@ -55,14 +55,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.1"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.2"
   ],
   "targets": [
     "tv"
   ],
   "platform": "tvos_for_quickbrick",
-  "manifest_version": "0.2.3-beta.1",
-  "dependency_version": "0.2.3-beta.1",
+  "manifest_version": "0.2.3-beta.2",
+  "dependency_version": "0.2.3-beta.2",
   "extra_dependencies": [
     {
       "ZappCmpOneTrust": ":path => './node_modules/@applicaster/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec'"
@@ -168,9 +168,21 @@
             "initial_value": "rgba(84, 90, 92, 1)"
           },
           {
+            "key": "intro_button_focused_fontcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Font Color for Intro Button Focused Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
             "key": "intro_button_backgroundcolor",
             "type": "color_picker_rgba",
             "label_tooltip": "Background Color for Intro Button Text.",
+            "initial_value": "rgba(84, 90, 92, 1)"
+          },
+          {
+            "key": "intro_button_focused_backgroundcolor",
+            "type": "color_picker_rgba",
+            "label_tooltip": "Background Color for Intro Button Focused Text",
             "initial_value": "rgba(84, 90, 92, 1)"
           }
         ]

--- a/plugins/applicaster-cmp-onetrust/manifests/tvos_for_quickbrick.json
+++ b/plugins/applicaster-cmp-onetrust/manifests/tvos_for_quickbrick.json
@@ -55,14 +55,14 @@
   ],
   "identifier": "applicaster-cmp-onetrust",
   "npm_dependencies": [
-    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.2"
+    "@applicaster/applicaster-cmp-onetrust@0.2.3-beta.3"
   ],
   "targets": [
     "tv"
   ],
   "platform": "tvos_for_quickbrick",
-  "manifest_version": "0.2.3-beta.2",
-  "dependency_version": "0.2.3-beta.2",
+  "manifest_version": "0.2.3-beta.3",
+  "dependency_version": "0.2.3-beta.3",
   "extra_dependencies": [
     {
       "ZappCmpOneTrust": ":path => './node_modules/@applicaster/applicaster-cmp-onetrust/apple/ZappCmpOneTrust.podspec'"

--- a/plugins/applicaster-cmp-onetrust/package.json
+++ b/plugins/applicaster-cmp-onetrust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/applicaster-cmp-onetrust",
-  "version": "0.2.2",
+  "version": "0.2.3-beta.0",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/plugins/applicaster-cmp-onetrust/package.json
+++ b/plugins/applicaster-cmp-onetrust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/applicaster-cmp-onetrust",
-  "version": "0.2.3-beta.2",
+  "version": "0.2.3-beta.3",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/plugins/applicaster-cmp-onetrust/package.json
+++ b/plugins/applicaster-cmp-onetrust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/applicaster-cmp-onetrust",
-  "version": "0.2.3-beta.0",
+  "version": "0.2.3-beta.1",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/plugins/applicaster-cmp-onetrust/package.json
+++ b/plugins/applicaster-cmp-onetrust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/applicaster-cmp-onetrust",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/plugins/applicaster-cmp-onetrust/package.json
+++ b/plugins/applicaster-cmp-onetrust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/applicaster-cmp-onetrust",
-  "version": "0.2.3-beta.1",
+  "version": "0.2.3-beta.2",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/plugins/applicaster-cmp-onetrust/src/components/Button.js
+++ b/plugins/applicaster-cmp-onetrust/src/components/Button.js
@@ -1,0 +1,64 @@
+import React from "react";
+import { Text, ImageBackground, StyleSheet } from "react-native";
+import { Focusable } from "@applicaster/zapp-react-native-ui-components/Components/Focusable";
+
+export default function Button({
+  label = "",
+  onPress,
+  preferredFocus,
+  buttonRef,
+  nextFocusDown,
+  nextFocusUp,
+  groupId,
+  textStyle = {},
+  backgroundColor = "",
+  backgroundButtonUri = "",
+  backgroundButtonUriActive = "",
+}) {
+  const buttonStyle = { ...styles.input, backgroundColor };
+    
+  return (
+    <Focusable
+      id={`tv-button-${label}`}
+      onPress={onPress}
+      groupId={groupId}
+      preferredFocus={preferredFocus}
+      ref={buttonRef}
+      nextFocusDown={nextFocusDown}
+      nextFocusUp={nextFocusUp}
+    >
+      {(focused) => {
+        return (
+          <ImageBackground
+            source={{
+              uri: focused ? backgroundButtonUriActive : backgroundButtonUri,
+            }}
+            style={[buttonStyle, styles.opacity(focused)]}
+          >
+            <Text
+              style={focused ? styles.textStyle(textStyle) : textStyle}
+              numberOfLines={2}
+              ellipsizeMode="tail"
+            >
+              {label}
+            </Text>
+          </ImageBackground>
+        );
+      }}
+    </Focusable>
+  );
+}
+
+const COLOR = "#5F5F5F";
+
+const styles = StyleSheet.create({
+  input: {
+    width: 600,
+    height: 90,
+    justifyContent: "center",
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  opacity: (focused) => ({ opacity: focused ? 1 : 0.9 }),
+  textStyle: (textStyle) => ({ ...textStyle, color: COLOR }),
+});

--- a/plugins/applicaster-cmp-onetrust/src/components/Button.js
+++ b/plugins/applicaster-cmp-onetrust/src/components/Button.js
@@ -14,6 +14,7 @@ export default function Button({
   backgroundColor = "",
   backgroundButtonUri = "",
   backgroundButtonUriActive = "",
+  focusedTextColor = ""
 }) {
   const buttonStyle = { ...styles.input, backgroundColor };
     
@@ -36,7 +37,7 @@ export default function Button({
             style={[buttonStyle, styles.opacity(focused)]}
           >
             <Text
-              style={focused ? styles.textStyle(textStyle) : textStyle}
+              style={focused ? styles.textStyle(textStyle, focusedTextColor) : textStyle}
               numberOfLines={2}
               ellipsizeMode="tail"
             >
@@ -49,8 +50,6 @@ export default function Button({
   );
 }
 
-const COLOR = "#5F5F5F";
-
 const styles = StyleSheet.create({
   input: {
     width: 600,
@@ -60,5 +59,5 @@ const styles = StyleSheet.create({
     marginBottom: 10,
   },
   opacity: (focused) => ({ opacity: focused ? 1 : 0.9 }),
-  textStyle: (textStyle) => ({ ...textStyle, color: COLOR }),
+  textStyle: (textStyle, focusedTextColor) => ({ ...textStyle, color: focusedTextColor }),
 });

--- a/plugins/applicaster-cmp-onetrust/src/components/Button.js
+++ b/plugins/applicaster-cmp-onetrust/src/components/Button.js
@@ -9,6 +9,7 @@ export default function Button({
   buttonRef,
   nextFocusDown,
   nextFocusUp,
+  nextFocusLeft,
   groupId,
   textStyle = {},
   backgroundColor = "",
@@ -27,6 +28,7 @@ export default function Button({
       ref={buttonRef}
       nextFocusDown={nextFocusDown}
       nextFocusUp={nextFocusUp}
+      nextFocusLeft={nextFocusLeft}
     >
       {(focused) => {
         return (

--- a/plugins/applicaster-cmp-onetrust/src/index.js
+++ b/plugins/applicaster-cmp-onetrust/src/index.js
@@ -105,6 +105,9 @@ export default NativeScreen = ({ screenData }: Props) => {
   };
 
   const onDismiss = () => {
+    if (showIntroScreen) {
+      return;
+    }
     // todo: this exit action should be customizible: go back or go home/other screen
     // manifest already has fields set up for this behavior
     if (navigator.canGoBack()) {

--- a/plugins/applicaster-cmp-onetrust/src/index.js
+++ b/plugins/applicaster-cmp-onetrust/src/index.js
@@ -54,7 +54,9 @@ export default NativeScreen = ({ screenData }: Props) => {
     [`intro_button_font_${platformEndpoint}`]: introButtonFont,
     intro_button_fontsize: introButtonFontSize,
     intro_button_fontcolor: introButtonFontColor,
-    intro_button_backgroundcolor: introBackgroundColor
+    intro_button_backgroundcolor: introBackgroundColor,
+    intro_button_focused_fontcolor: introButtonFocusedColor,
+    intro_button_focused_backgroundcolor: introButtonFocusedBgColor
   } = generalData;
 
   const buttonStyle = {
@@ -87,6 +89,8 @@ export default NativeScreen = ({ screenData }: Props) => {
           onPress={openNativeScreen}
           textStyle={buttonStyle}
           backgroundColor={introBackgroundColor}
+          backgroundButtonUriActive={introButtonFocusedBgColor}
+          focusedTextColor={introButtonFocusedColor}
         />
       </View>
     );

--- a/plugins/applicaster-cmp-onetrust/src/index.js
+++ b/plugins/applicaster-cmp-onetrust/src/index.js
@@ -59,7 +59,7 @@ export default NativeScreen = ({ screenData }: Props) => {
 
   const buttonStyle = {
     color: introButtonFontColor,
-    fontSize: introButtonFontSize,
+    fontSize: Number(introButtonFontSize),
     fontFamily: introButtonFont
   };
 

--- a/plugins/applicaster-cmp-onetrust/src/index.js
+++ b/plugins/applicaster-cmp-onetrust/src/index.js
@@ -53,7 +53,8 @@ export default NativeScreen = ({ screenData }: Props) => {
     intro_button_text: introButtonText,
     [`intro_button_font_${platformEndpoint}`]: introButtonFont,
     intro_button_fontsize: introButtonFontSize,
-    intro_button_fontcolor: introButtonFontColor
+    intro_button_fontcolor: introButtonFontColor,
+    intro_button_backgroundcolor: introBackgroundColor
   } = generalData;
 
   const buttonStyle = {
@@ -85,7 +86,7 @@ export default NativeScreen = ({ screenData }: Props) => {
           label={introButtonText}
           onPress={openNativeScreen}
           textStyle={buttonStyle}
-          backgroundColor={"#000000"}
+          backgroundColor={introBackgroundColor}
         />
       </View>
     );

--- a/plugins/applicaster-cmp-onetrust/src/utils.js
+++ b/plugins/applicaster-cmp-onetrust/src/utils.js
@@ -44,3 +44,13 @@ export const DEFAULT = {
   packageName: getFromManifest("general", "package_name")?.default,
   methodName: getFromManifest("general", "method_name")?.default,
 };
+
+export const parseFontKey = (platform) => {
+  const endpoints = {
+    ios: "tvos",
+    android: "android",
+    samsung_tv: "samsung",
+  };
+
+  return endpoints[platform];
+};


### PR DESCRIPTION
If merged this will add a switch field to enable/disable the `Intro screen` a previous state before the native screen also adds fields to configure the styles of the button in the screen.

![Simulator Screen Shot - Apple TV - 2021-07-06 at 14 16 39](https://user-images.githubusercontent.com/6458055/124665180-06674000-de72-11eb-82d7-e57514ee5603.png)
