### PR TITLE
fix: mapKeyToStyle was refering to a method that didn't exist

### DIFF
--- a/plugins/applicaster-account-components/src/Utils/Customization/index.js
+++ b/plugins/applicaster-account-components/src/Utils/Customization/index.js
@@ -2,6 +2,18 @@ import * as R from "ramda";
 
 import { platformSelect } from "@applicaster/zapp-react-native-utils/reactUtils";
 
+const mapInputKeyToStyle = (key, obj) => {
+  return {
+    backgroundColor: obj?.[`${key}_background`],
+    backgroundColor_filled: obj?.[`${key}_background_filled`],
+    backgroundColor_focused: obj?.[`${key}_background_focused`],
+    borderColor: obj?.[`${key}_border_color`],
+    borderColor_filled: obj?.[`${key}_border_color_filled`],
+    borderColor_focused: obj?.[`${key}_border_color_focused`],
+    placeholderTextColor: obj?.[`${key}_placeholder_color`],
+  };
+};
+
 export const mapKeyToStyle = R.curry((key, obj) => {
   const isInputKey = key.includes("input");
   const inputStyleObj = isInputKey ? mapInputKeyToStyle(key, obj) : null;

--- a/plugins/quick-brick-inplayer-login/package.json
+++ b/plugins/quick-brick-inplayer-login/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@applicaster/applicaster-account-components": "0.1.3",
+    "@applicaster/applicaster-account-components": "0.1.7-alpha.0",
     "@applicaster/quick-brick-parent-lock": "*",
     "@inplayer-org/inplayer.js": "3.11.1",
     "@react-native-community/blur": "3.4.1",


### PR DESCRIPTION
### Description

This PR addresses a small issue that was causing the applicaster-account-component screen... used by InPlayer Login screen to crash. The issue was that we were utilizing a method that did not exist.

### Before Fix

![Screenshot_1625789304](https://user-images.githubusercontent.com/2348227/125004981-a070e900-e028-11eb-8a7f-b2be22bf2a5d.png)


### After Fix

![Screenshot_1625789377](https://user-images.githubusercontent.com/2348227/125004985-a4047000-e028-11eb-9329-88a882250beb.png)

#### Pending 

Was going to include this UI change in this PR but I think its best that we just merge this fix.
https://scene.zeplin.io/project/6088402e4a714f01ede68d7b/screen/608844ade4311706261892eb