### PR TITLE
Fix/inplayer login token

### DIFF
--- a/plugins/quick-brick-inplayer-login/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-login/manifests/amazon_fire_tv_for_quickbrick.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "dependency_version": "8.0.5",
-  "manifest_version": "8.0.5",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-login/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-login/manifests/amazon_fire_tv_for_quickbrick.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "8.0.6-alpha.1",
+  "manifest_version": "8.0.6-alpha.1",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-login/manifests/android_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-login/manifests/android_for_quickbrick.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "android_for_quickbrick",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "8.0.6-alpha.1",
+  "manifest_version": "8.0.6-alpha.1",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-login/manifests/android_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-login/manifests/android_for_quickbrick.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "android_for_quickbrick",
-  "dependency_version": "8.0.5",
-  "manifest_version": "8.0.5",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-login/manifests/android_tv_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-login/manifests/android_tv_for_quickbrick.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "android_tv_for_quickbrick",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "8.0.6-alpha.1",
+  "manifest_version": "8.0.6-alpha.1",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-login/manifests/android_tv_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-login/manifests/android_tv_for_quickbrick.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "android_tv_for_quickbrick",
-  "dependency_version": "8.0.5",
-  "manifest_version": "8.0.5",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-login/manifests/ios_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-login/manifests/ios_for_quickbrick.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "ios_for_quickbrick",
-  "dependency_version": "8.0.5",
-  "manifest_version": "8.0.5",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/quick-brick-inplayer-login/manifests/ios_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-login/manifests/ios_for_quickbrick.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "ios_for_quickbrick",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "8.0.6-alpha.1",
+  "manifest_version": "8.0.6-alpha.1",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/quick-brick-inplayer-login/manifests/lg_tv.json
+++ b/plugins/quick-brick-inplayer-login/manifests/lg_tv.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "lg_tv",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "8.0.6-alpha.1",
+  "manifest_version": "8.0.6-alpha.1",
   "api": {
     "excludedNodeModules": [
       "react-native-dropdownalert",

--- a/plugins/quick-brick-inplayer-login/manifests/lg_tv.json
+++ b/plugins/quick-brick-inplayer-login/manifests/lg_tv.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "lg_tv",
-  "dependency_version": "8.0.5",
-  "manifest_version": "8.0.5",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {
     "excludedNodeModules": [
       "react-native-dropdownalert",

--- a/plugins/quick-brick-inplayer-login/manifests/samsung_tv.json
+++ b/plugins/quick-brick-inplayer-login/manifests/samsung_tv.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "samsung_tv",
-  "dependency_version": "8.0.5",
-  "manifest_version": "8.0.5",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {
     "excludedNodeModules": [
       "react-native-dropdownalert",

--- a/plugins/quick-brick-inplayer-login/manifests/samsung_tv.json
+++ b/plugins/quick-brick-inplayer-login/manifests/samsung_tv.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "samsung_tv",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "8.0.6-alpha.1",
+  "manifest_version": "8.0.6-alpha.1",
   "api": {
     "excludedNodeModules": [
       "react-native-dropdownalert",

--- a/plugins/quick-brick-inplayer-login/manifests/tvos_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-login/manifests/tvos_for_quickbrick.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "tvos_for_quickbrick",
-  "dependency_version": "8.0.5",
-  "manifest_version": "8.0.5",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/quick-brick-inplayer-login/manifests/tvos_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-login/manifests/tvos_for_quickbrick.json
@@ -93,8 +93,8 @@
     "quickbrick"
   ],
   "platform": "tvos_for_quickbrick",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "8.0.6-alpha.1",
+  "manifest_version": "8.0.6-alpha.1",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/quick-brick-inplayer-login/package.json
+++ b/plugins/quick-brick-inplayer-login/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-inplayer",
-  "version": "8.0.5",
+  "version": "8.0.6-alpha.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/plugins/quick-brick-inplayer-login/package.json
+++ b/plugins/quick-brick-inplayer-login/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-inplayer",
-  "version": "8.0.6-alpha.0",
+  "version": "8.0.6-alpha.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/plugins/quick-brick-inplayer-login/src/Components/InPlayerLogin.js
+++ b/plugins/quick-brick-inplayer-login/src/Components/InPlayerLogin.js
@@ -159,7 +159,7 @@ const InPlayerLogin = (props) => {
       getItem: async function () {
         const token = await localStorageGet(localStorageTokenKey);
 
-        return token;
+        return JSON.stringify(token);
       },
       removeItem: async function () {
         await localStorageRemove(localStorageTokenKey);

--- a/plugins/quick-brick-inplayer-login/src/Components/InPlayerLogin.js
+++ b/plugins/quick-brick-inplayer-login/src/Components/InPlayerLogin.js
@@ -158,6 +158,7 @@ const InPlayerLogin = (props) => {
       },
       getItem: async function () {
         const token = await localStorageGet(localStorageTokenKey);
+
         return token;
       },
       removeItem: async function () {
@@ -168,13 +169,23 @@ const InPlayerLogin = (props) => {
 
     setLastEmailUsed((await InPlayerService.getLastEmailUsed()) || null);
 
-    const { token } = await InPlayerSDK.Account.getToken();
-    setIdtoken(token);
+    try {
+      const { token } = await InPlayerSDK.Account.getToken();
+      setIdtoken(token);
+    } catch(err) {
+      logger.debug({
+        message: `Error getting InPlayer Token`,
+        data: {
+          err
+        },
+      });
+    }
 
     logger.debug({
       message: "Starting InPlayer Plugin",
       data: { configuration: props?.configuration },
     });
+
     let shouldBeSkipped = payload?.extensions?.skip_hook;
 
     if (show_hook_once) {

--- a/plugins/quick-brick-inplayer-login/src/Components/InPlayerLogin.js
+++ b/plugins/quick-brick-inplayer-login/src/Components/InPlayerLogin.js
@@ -290,7 +290,7 @@ const InPlayerLogin = (props) => {
         const { callback } = props;
         event.setMessage(`${eventMessage}, plugin finished task`).send();
         if (payload) {
-          let newPayload = payload;
+          let newPayload = { ...payload };
           if (newPayload.extensions) {
             newPayload.extensions = {
               ...payload.extensions,

--- a/plugins/quick-brick-inplayer-storefront/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/amazon_fire_tv_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "dependency_version": "0.0.17",
-  "manifest_version": "0.0.17",
+  "dependency_version": "0.0.18-beta.0",
+  "manifest_version": "0.0.18-beta.0",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/amazon_fire_tv_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "dependency_version": "0.0.18-beta.0",
-  "manifest_version": "0.0.18-beta.0",
+  "dependency_version": "0.0.18-beta.1",
+  "manifest_version": "0.0.18-beta.1",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/amazon_fire_tv_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "0.0.18-beta.2",
+  "manifest_version": "0.0.18-beta.2",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/amazon_fire_tv_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/amazon_fire_tv_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "amazon_fire_tv_for_quickbrick",
-  "dependency_version": "0.0.18-beta.1",
-  "manifest_version": "0.0.18-beta.1",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/android_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/android_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "android_for_quickbrick",
-  "dependency_version": "0.0.18-beta.1",
-  "manifest_version": "0.0.18-beta.1",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/android_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/android_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "android_for_quickbrick",
-  "dependency_version": "0.0.18-beta.0",
-  "manifest_version": "0.0.18-beta.0",
+  "dependency_version": "0.0.18-beta.1",
+  "manifest_version": "0.0.18-beta.1",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/android_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/android_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "android_for_quickbrick",
-  "dependency_version": "0.0.17",
-  "manifest_version": "0.0.17",
+  "dependency_version": "0.0.18-beta.0",
+  "manifest_version": "0.0.18-beta.0",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/android_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/android_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "android_for_quickbrick",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "0.0.18-beta.2",
+  "manifest_version": "0.0.18-beta.2",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/android_tv_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/android_tv_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "android_tv_for_quickbrick",
-  "dependency_version": "0.0.18-beta.0",
-  "manifest_version": "0.0.18-beta.0",
+  "dependency_version": "0.0.18-beta.1",
+  "manifest_version": "0.0.18-beta.1",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/android_tv_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/android_tv_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "android_tv_for_quickbrick",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "0.0.18-beta.2",
+  "manifest_version": "0.0.18-beta.2",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/android_tv_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/android_tv_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "android_tv_for_quickbrick",
-  "dependency_version": "0.0.18-beta.1",
-  "manifest_version": "0.0.18-beta.1",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/android_tv_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/android_tv_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "android_tv_for_quickbrick",
-  "dependency_version": "0.0.17",
-  "manifest_version": "0.0.17",
+  "dependency_version": "0.0.18-beta.0",
+  "manifest_version": "0.0.18-beta.0",
   "api": {
     "class_name": "com.applicaster.reactnative.plugins.APReactNativeAdapter",
     "react_packages": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/ios_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/ios_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "ios_for_quickbrick",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "0.0.18-beta.2",
+  "manifest_version": "0.0.18-beta.2",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/ios_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/ios_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "ios_for_quickbrick",
-  "dependency_version": "0.0.18-beta.1",
-  "manifest_version": "0.0.18-beta.1",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/ios_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/ios_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "ios_for_quickbrick",
-  "dependency_version": "0.0.17",
-  "manifest_version": "0.0.17",
+  "dependency_version": "0.0.18-beta.0",
+  "manifest_version": "0.0.18-beta.0",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/ios_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/ios_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "ios_for_quickbrick",
-  "dependency_version": "0.0.18-beta.0",
-  "manifest_version": "0.0.18-beta.0",
+  "dependency_version": "0.0.18-beta.1",
+  "manifest_version": "0.0.18-beta.1",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/lg_tv.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/lg_tv.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "lg_tv",
-  "dependency_version": "0.0.17",
-  "manifest_version": "0.0.17",
+  "dependency_version": "0.0.18-beta.0",
+  "manifest_version": "0.0.18-beta.0",
   "api": {
     "excludedNodeModules": [
       "@applicaster/applicaster-iap",

--- a/plugins/quick-brick-inplayer-storefront/manifests/lg_tv.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/lg_tv.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "lg_tv",
-  "dependency_version": "0.0.18-beta.0",
-  "manifest_version": "0.0.18-beta.0",
+  "dependency_version": "0.0.18-beta.1",
+  "manifest_version": "0.0.18-beta.1",
   "api": {
     "excludedNodeModules": [
       "@applicaster/applicaster-iap",

--- a/plugins/quick-brick-inplayer-storefront/manifests/lg_tv.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/lg_tv.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "lg_tv",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "0.0.18-beta.2",
+  "manifest_version": "0.0.18-beta.2",
   "api": {
     "excludedNodeModules": [
       "@applicaster/applicaster-iap",

--- a/plugins/quick-brick-inplayer-storefront/manifests/lg_tv.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/lg_tv.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "lg_tv",
-  "dependency_version": "0.0.18-beta.1",
-  "manifest_version": "0.0.18-beta.1",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {
     "excludedNodeModules": [
       "@applicaster/applicaster-iap",

--- a/plugins/quick-brick-inplayer-storefront/manifests/samsung_tv.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/samsung_tv.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "samsung_tv",
-  "dependency_version": "0.0.18-beta.0",
-  "manifest_version": "0.0.18-beta.0",
+  "dependency_version": "0.0.18-beta.1",
+  "manifest_version": "0.0.18-beta.1",
   "api": {
     "excludedNodeModules": [
       "@applicaster/applicaster-iap",

--- a/plugins/quick-brick-inplayer-storefront/manifests/samsung_tv.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/samsung_tv.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "samsung_tv",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "0.0.18-beta.2",
+  "manifest_version": "0.0.18-beta.2",
   "api": {
     "excludedNodeModules": [
       "@applicaster/applicaster-iap",

--- a/plugins/quick-brick-inplayer-storefront/manifests/samsung_tv.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/samsung_tv.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "samsung_tv",
-  "dependency_version": "0.0.18-beta.1",
-  "manifest_version": "0.0.18-beta.1",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {
     "excludedNodeModules": [
       "@applicaster/applicaster-iap",

--- a/plugins/quick-brick-inplayer-storefront/manifests/samsung_tv.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/samsung_tv.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "samsung_tv",
-  "dependency_version": "0.0.17",
-  "manifest_version": "0.0.17",
+  "dependency_version": "0.0.18-beta.0",
+  "manifest_version": "0.0.18-beta.0",
   "api": {
     "excludedNodeModules": [
       "@applicaster/applicaster-iap",

--- a/plugins/quick-brick-inplayer-storefront/manifests/tvos_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/tvos_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "tvos_for_quickbrick",
-  "dependency_version": "0.0.18-beta.0",
-  "manifest_version": "0.0.18-beta.0",
+  "dependency_version": "0.0.18-beta.1",
+  "manifest_version": "0.0.18-beta.1",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/tvos_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/tvos_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "tvos_for_quickbrick",
-  "dependency_version": "0.0.18-beta.1",
-  "manifest_version": "0.0.18-beta.1",
+  "dependency_version": "8.0.6-alpha.0",
+  "manifest_version": "8.0.6-alpha.0",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/tvos_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/tvos_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "tvos_for_quickbrick",
-  "dependency_version": "8.0.6-alpha.0",
-  "manifest_version": "8.0.6-alpha.0",
+  "dependency_version": "0.0.18-beta.2",
+  "manifest_version": "0.0.18-beta.2",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/quick-brick-inplayer-storefront/manifests/tvos_for_quickbrick.json
+++ b/plugins/quick-brick-inplayer-storefront/manifests/tvos_for_quickbrick.json
@@ -117,8 +117,8 @@
     "quickbrick"
   ],
   "platform": "tvos_for_quickbrick",
-  "dependency_version": "0.0.17",
-  "manifest_version": "0.0.17",
+  "dependency_version": "0.0.18-beta.0",
+  "manifest_version": "0.0.18-beta.0",
   "api": {},
   "project_dependencies": [],
   "extra_dependencies": [

--- a/plugins/quick-brick-inplayer-storefront/package.json
+++ b/plugins/quick-brick-inplayer-storefront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-inplayer-storefront",
-  "version": "8.0.6-alpha.0",
+  "version": "0.0.18-beta.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/plugins/quick-brick-inplayer-storefront/package.json
+++ b/plugins/quick-brick-inplayer-storefront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-inplayer-storefront",
-  "version": "0.0.17",
+  "version": "0.0.18-beta.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/plugins/quick-brick-inplayer-storefront/package.json
+++ b/plugins/quick-brick-inplayer-storefront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-inplayer-storefront",
-  "version": "0.0.18-beta.0",
+  "version": "0.0.18-beta.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/plugins/quick-brick-inplayer-storefront/package.json
+++ b/plugins/quick-brick-inplayer-storefront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/quick-brick-inplayer-storefront",
-  "version": "0.0.18-beta.1",
+  "version": "8.0.6-alpha.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/plugins/quick-brick-inplayer-storefront/src/Components/InPlayer.js
+++ b/plugins/quick-brick-inplayer-storefront/src/Components/InPlayer.js
@@ -86,7 +86,7 @@ const InPlayer = (props) => {
       },
       getItem: async function () {
         const token = await localStorageGet(localStorageTokenKey);
-        return token;
+        return JSON.stringify(token);
       },
       removeItem: async function () {
         await localStorageRemove(localStorageTokenKey);


### PR DESCRIPTION
If merged this will fix an issue on the `invideo-login` and `invideo-storefront` plugin related to this call

```
const { token } = await InPlayerSDK.Account.getToken();
```

Where the SDK side is expecting a string but the QB implementation is parsing and storing the token as a JS object so the solution was to stringify the token get using the getItem override

```
      getItem: async function () {
        const token = await localStorageGet(localStorageTokenKey);

        return JSON.stringify(token);
      },
```