### PR TITLE
fix: refactor to plugin subtypes to get the subtype string from api

### DIFF
--- a/plugins/applicaster-cmp-didomi/manifests/manifest.config.js
+++ b/plugins/applicaster-cmp-didomi/manifests/manifest.config.js
@@ -181,6 +181,7 @@ const api_apple = {
     NSUserTrackingUsageDescription:
       "This identifier will be used to deliver personalized ads to you.",
   },
+  subtype: "general.cmp"
 };
 
 const api_android = {

--- a/plugins/applicaster-cmp-onetrust/manifests/manifest.config.js
+++ b/plugins/applicaster-cmp-onetrust/manifests/manifest.config.js
@@ -253,6 +253,7 @@ const api_apple = {
   require_startup_execution: true,
   class_name: "OneTrustCmp",
   modules: ["ZappCmpOneTrust"],
+  subtype: "general.cmp"
 };
 
 const api_android = {

--- a/plugins/applicaster-di-manager/apple/universal/ZPDiManager.swift
+++ b/plugins/applicaster-di-manager/apple/universal/ZPDiManager.swift
@@ -45,7 +45,7 @@ import ZappCore
 
     public func disable(completion: ((Bool) -> Void)?) {
         _ = FacadeConnector.connector?.storage?.sessionStorageRemoveValue(for: Params.jwtStorageKey,
-                                                                        namespace: nil)
+                                                                          namespace: nil)
         completion?(true)
     }
 

--- a/plugins/applicaster-di-manager/manifests/manifest.config.js
+++ b/plugins/applicaster-di-manager/manifests/manifest.config.js
@@ -76,8 +76,8 @@ const custom_configuration_fields = {
 };
 
 const min_zapp_sdk = {
-  ios_for_quickbrick: "3.0.0-Dev",
-  tvos_for_quickbrick: "3.0.0-Dev",
+  ios_for_quickbrick: "5.1.0-Dev",
+  tvos_for_quickbrick: "5.1.0-Dev",
   android_for_quickbrick: "2.0.0",
   android_tv_for_quickbrick: "2.0.0",
   amazon_fire_tv_for_quickbrick: "2.0.0",
@@ -117,9 +117,10 @@ const project_dependencies = {
 };
 
 const api_apple = {
-  require_startup_execution: false,
+  require_startup_execution: true,
   class_name: "ZPDiManager",
   modules: ["ZappDiManager"],
+  subtype: "general.storage"
 };
 
 const api_android = {

--- a/plugins/remote-info-to-session-storage/apple/universal/ZPRemoteInfoToSessionStorage.swift
+++ b/plugins/remote-info-to-session-storage/apple/universal/ZPRemoteInfoToSessionStorage.swift
@@ -89,7 +89,7 @@ import ZappCore
                                           data: ["url": urlString,
                                                  "error": error.localizedDescription])
                 }
-                
+
                 if self.shouldWaitForCompletion {
                     completion?(true)
                 }

--- a/plugins/remote-info-to-session-storage/manifests/manifest.config.js
+++ b/plugins/remote-info-to-session-storage/manifests/manifest.config.js
@@ -125,6 +125,7 @@ const api_apple = {
   require_startup_execution: true,
   class_name: "ZPRemoteInfoToSessionStorage",
   modules: ["ZappRemoteInfoToSessionStorage"],
+  subtype: "general.storage"
 };
 
 const api_android = {


### PR DESCRIPTION
refactor to plugin subtypes to get the subtype string from api on plugin manifest and not rely on identifier substring