### PR TITLE
fix: added ability to use several chromecast buttons for zapp-generic-chromecast

### DIFF
--- a/plugins/zapp-generic-chromecast/apple/ios/Extensions/ChromecastAdapter+ChromecastProtocol.swift
+++ b/plugins/zapp-generic-chromecast/apple/ios/Extensions/ChromecastAdapter+ChromecastProtocol.swift
@@ -254,10 +254,7 @@ extension ChromecastAdapter: ChromecastProtocol {
     }
     
     fileprivate func createButtonIfNeeded(frame: CGRect) {
-        guard castButton == nil else {
-            return
-        }
-        
+
         let button = createChromecastButton(frame: frame)
         
         // catch tap event for analytics


### PR DESCRIPTION
Related task: https://applicaster.monday.com/boards/1141653998/pulses/1512956447.
Behaviour before fix:
https://drive.google.com/file/d/1j-lu_VwtpRVv4xIqdZHz4HYSpxvnhhF8/view
Behaviour after fix:
https://user-images.githubusercontent.com/76045389/127443026-5a54b813-66d2-45c3-9f1b-51189ac5c334.mov

