### PR TITLE
Fix gemius events

### DIFF
--- a/plugins/zapp-analytics-plugin-gemius/android/src/main/java/com/applicaster/analytics/gemius/GemiusAgent.kt
+++ b/plugins/zapp-analytics-plugin-gemius/android/src/main/java/com/applicaster/analytics/gemius/GemiusAgent.kt
@@ -1,7 +1,7 @@
 package com.applicaster.analytics.gemius
 
 import com.applicaster.analytics.BaseAnalyticsAgent
-import com.applicaster.analytics.adapters.IAnalyticsAdapter
+import com.applicaster.analytics.gemius.adapters.IAnalyticsAdapter
 import com.applicaster.session.SessionStorage
 import com.applicaster.util.APDebugUtil
 import com.applicaster.util.APLogger

--- a/plugins/zapp-analytics-plugin-gemius/android/src/main/java/com/applicaster/analytics/gemius/PlayerAdapter.kt
+++ b/plugins/zapp-analytics-plugin-gemius/android/src/main/java/com/applicaster/analytics/gemius/PlayerAdapter.kt
@@ -16,10 +16,10 @@ class PlayerAdapter(playerID: String,
     init {
         player.setContext(AppContext.get())
     }
-
     override fun getId(): String = idOverride ?: super.getId()
 
     private var isPlaying: Boolean = false // hack to suppress excessive play events
+    private var onMidRoll: Boolean = false // hack to report play after midroll
 
     override fun onStart(params: Map<String, Any>?) {
         super.onStart(params)
@@ -31,6 +31,9 @@ class PlayerAdapter(playerID: String,
         pdata.duration = duration?.toInt()
         // todo: need to determine type
         pdata.programType = ProgramData.ProgramType.VIDEO
+
+        onMidRoll = false
+        isPlaying = false
 
         var id = super.getId()
 
@@ -82,7 +85,8 @@ class PlayerAdapter(playerID: String,
         player.newProgram(id, pdata)
     }
 
-    private fun reportEvent(event: Player.EventType) {
+    private fun reportEvent(event: Player.EventType, sender: String) {
+        APLogger.debug(GemiusAgent.TAG, "Reporting event $event at $position from $sender")
         player.programEvent(
                 getId(),
                 position?.toInt() ?: 0,
@@ -93,32 +97,32 @@ class PlayerAdapter(playerID: String,
     override fun onPlay(params: Map<String, Any>?) {
         super.onPlay(params)
         if(isPlaying) return
-        reportEvent(Player.EventType.PLAY)
+        reportEvent(Player.EventType.PLAY, "onPlay")
         isPlaying = true
     }
 
     override fun onStop(params: Map<String, Any>?) {
         super.onStop(params)
         isPlaying = false
-        reportEvent(Player.EventType.CLOSE) // stop is close for us
+        reportEvent(Player.EventType.CLOSE, "onStop") // stop is close for us
     }
 
     override fun onPause(params: Map<String, Any>?) {
         super.onPause(params)
         isPlaying = false
-        reportEvent(Player.EventType.PAUSE)
+        reportEvent(Player.EventType.PAUSE, "onPause")
     }
 
     override fun onResume(params: Map<String, Any>?) {
         super.onResume(params)
         if(isPlaying) return
-        reportEvent(Player.EventType.PLAY)
+        reportEvent(Player.EventType.PLAY, "onResume")
         isPlaying = true
     }
 
     override fun onBuffering(params: Map<String, Any>?) {
         super.onBuffering(params)
-        reportEvent(Player.EventType.BUFFER)
+        reportEvent(Player.EventType.BUFFER, "onBuffering")
     }
 
     override fun onAdBreakStart(params: Map<String, Any>?) {
@@ -133,12 +137,16 @@ class PlayerAdapter(playerID: String,
                 return
             }
         }
-        reportEvent(Player.EventType.BREAK)
+        onMidRoll = true
+        reportEvent(Player.EventType.BREAK, "onAdBreakStart")
     }
 
     override fun onAdBreakEnd(params: Map<String, Any>?) {
         super.onAdBreakEnd(params)
-        // not reported
+        if(onMidRoll) {
+            onMidRoll = false
+            reportEvent(Player.EventType.PLAY, "onAdBreakEnd")
+        }
     }
 
     override fun onAdStart(params: Map<String, Any>?) {
@@ -158,7 +166,7 @@ class PlayerAdapter(playerID: String,
         player.newAd(id, adata)
         player.adEvent(
                 getId(),
-                id, position?.toInt(),
+                id, position?.toInt(), // todo: wrong position received there
                 Player.EventType.PLAY,
                 EventAdData().apply {
                     autoPlay = true // all our ads are autoplay I assume
@@ -168,6 +176,7 @@ class PlayerAdapter(playerID: String,
                         else -> APLogger.warn(GemiusAgent.TAG, "$KEY_AD_BREAK_SIZE is missing in the event $AD_START_EVENT data")
                     }
                 })
+        APLogger.debug(GemiusAgent.TAG, "Reporting Ad event ${Player.EventType.PLAY} at $position")
     }
 
     override fun onAdEnd(params: Map<String, Any>?) {
@@ -178,27 +187,28 @@ class PlayerAdapter(playerID: String,
         player.adEvent(
                 getId(),
                 id,
-                position?.toInt(),
+                position?.toInt(), // todo: wrong position received there
                 Player.EventType.COMPLETE,
                 null)
+        APLogger.debug(GemiusAgent.TAG, "Reporting Ad event ${Player.EventType.COMPLETE} at $position")
     }
 
     override fun onSeek(params: Map<String, Any>?) {
         super.onSeek(params)
         isPlaying = false
-        reportEvent(Player.EventType.SEEK)
+        reportEvent(Player.EventType.SEEK, "onSeek")
     }
 
     override fun onSeekEnd(params: Map<String, Any>?) {
         // Gemius requires Play event after seek
         super.onSeekEnd(params)
         isPlaying = true // event is received when we are already playing after the seek
-        reportEvent(Player.EventType.PLAY)
+        reportEvent(Player.EventType.PLAY, "onSeekEnd")
     }
 
     override fun onComplete(params: Map<String, Any>?) {
         super.onComplete(params)
-        reportEvent(Player.EventType.COMPLETE)
+        reportEvent(Player.EventType.COMPLETE, "onComplete")
     }
 
     companion object {

--- a/plugins/zapp-analytics-plugin-gemius/android/src/main/java/com/applicaster/analytics/gemius/ScreenAdapter.kt
+++ b/plugins/zapp-analytics-plugin-gemius/android/src/main/java/com/applicaster/analytics/gemius/ScreenAdapter.kt
@@ -1,6 +1,6 @@
 package com.applicaster.analytics.gemius
 
-import com.applicaster.analytics.adapters.AnalyticsScreenAdapter
+import com.applicaster.analytics.gemius.adapters.AnalyticsScreenAdapter
 import com.applicaster.util.AppContext
 import com.gemius.sdk.audience.AudienceEvent
 import com.gemius.sdk.audience.BaseEvent

--- a/plugins/zapp-analytics-plugin-gemius/android/src/main/java/com/applicaster/analytics/gemius/adapters/AnalyticsPlayerAdapter.kt
+++ b/plugins/zapp-analytics-plugin-gemius/android/src/main/java/com/applicaster/analytics/gemius/adapters/AnalyticsPlayerAdapter.kt
@@ -1,4 +1,4 @@
-package com.applicaster.analytics.adapters
+package com.applicaster.analytics.gemius.adapters
 
 import androidx.annotation.CallSuper
 import java.util.*

--- a/plugins/zapp-analytics-plugin-gemius/android/src/main/java/com/applicaster/analytics/gemius/adapters/AnalyticsScreenAdapter.kt
+++ b/plugins/zapp-analytics-plugin-gemius/android/src/main/java/com/applicaster/analytics/gemius/adapters/AnalyticsScreenAdapter.kt
@@ -1,4 +1,4 @@
-package com.applicaster.analytics.adapters
+package com.applicaster.analytics.gemius.adapters
 
 import androidx.annotation.CallSuper
 import com.applicaster.util.APLogger

--- a/plugins/zapp-analytics-plugin-gemius/android/src/main/java/com/applicaster/analytics/gemius/adapters/IAnalyticsAdapter.kt
+++ b/plugins/zapp-analytics-plugin-gemius/android/src/main/java/com/applicaster/analytics/gemius/adapters/IAnalyticsAdapter.kt
@@ -1,4 +1,4 @@
-package com.applicaster.analytics.adapters
+package com.applicaster.analytics.gemius.adapters
 
 import java.util.*
 


### PR DESCRIPTION
Fixing Gemius events:
 - excessive Play events
 - report ad break for mid-rolls only (will also report for post rolls, since event data is not passed from RN)
